### PR TITLE
Fix for "undefined method `values' for nil:NilClass"

### DIFF
--- a/lib/feature/repository/yaml_repository.rb
+++ b/lib/feature/repository/yaml_repository.rb
@@ -40,12 +40,16 @@ module Feature
           raise ArgumentError, "content of #{@yaml_file_name} does not contain proper config"
         end
 
-        invalid_value = data['features'].values.detect { |value| ![true, false].include?(value) }
-        if invalid_value
-          raise ArgumentError, "#{invalid_value} is not allowed value in config, use true/false"
-        end
+        if data['features']
+          invalid_value = data['features'].values.detect { |value| ![true, false].include?(value) }
+          if invalid_value
+            raise ArgumentError, "#{invalid_value} is not allowed value in config, use true/false"
+          end
 
-        data['features']
+          data['features']
+        else
+          {}
+        end
       end
       private :read_and_parse_file_data
     end

--- a/spec/feature/yaml_repository_spec.rb
+++ b/spec/feature/yaml_repository_spec.rb
@@ -43,6 +43,21 @@ EOF
         @repo.active_features.should == [:feature_a_active]
       end
     end
+
+    # For example, when all your features are in production and working fine.
+    context "with no features" do
+      before(:each) do
+        fp = File.new(@filename, 'w')
+        fp.write <<"EOF";
+features:
+EOF
+        fp.close
+      end
+
+      it "should read active features new on each request" do
+        @repo.active_features.should == []
+      end
+    end
   end
 
   it "should raise exception on no file found" do


### PR DESCRIPTION
This was causing a problem for us today.  Basically, when you've cleared out all of your feature toggles, you'll get an exception.

The error was: `NoMethodError: undefined method 'values' for nil:NilClass`

New specs:

```
Feature::Repository::YamlRepository
  proper config file
    with no features
      should read active features new on each request
```
