### PR TITLE
Only load the generator if Rails is defined and Version is greater than 3

### DIFF
--- a/feature.gemspec
+++ b/feature.gemspec
@@ -2,7 +2,7 @@ require 'rubygems/package_task'
 
 Gem::Specification.new do |s|
   s.name = "feature"
-  s.version = "0.7.0"
+  s.version = "0.7.1"
 
   s.authors = ["Markus Gerdes"]
   s.email = %q{github@mgsnova.de}

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -22,8 +22,8 @@
 #
 module Feature
   require 'feature/repository'
-  # Only load the generator if Rails is defined
-  require 'feature/generators/install_generator' if defined?(Rails)
+  # Only load the generator if Rails is defined and Version is greater than 3
+  require 'feature/generators/install_generator' if defined?(Rails) and Rails::VERSION::STRING > "3"
 
   @repository = nil
   @active_features = nil


### PR DESCRIPTION
With this modification, the feature gem works for a Rails 2.3.18 application running in RubyEE 1.8.7.
