### PR TITLE
Support testing with multiple features

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ With this approach Feature is higly configurable and not bound to a specific kin
           # your test code
         end
 
-        Feature.run_with_deactivated(:feature_name) do
+        Feature.run_with_deactivated(:feature, :another_feature) do
           # your test code
         end
 

--- a/lib/feature/testing.rb
+++ b/lib/feature/testing.rb
@@ -21,15 +21,15 @@ module Feature
     @active_features = old_features
   end
 
-  # Execute the code block with the given feature deactive
+  # Execute the code block with the given features deactive
   #
   # Example usage:
-  #   Feature.run_with_deactivated(:feature) do
+  #   Feature.run_with_deactivated(:feature, :another_feature) do
   #     # your test code here
   #   end
-  def self.run_with_deactivated(feature)
+  def self.run_with_deactivated(*features)
     old_features = @active_features.dup
-    @active_features.delete(feature)
+    @active_features -= features
     yield
   ensure
     @active_features = old_features

--- a/spec/feature/testing_spec.rb
+++ b/spec/feature/testing_spec.rb
@@ -5,17 +5,20 @@ describe 'Feature testing support' do
   before(:all) do
     repository = Feature::Repository::SimpleRepository.new
     repository.add_active_feature(:active_feature)
+    repository.add_active_feature(:another_active_feature)
     Feature.set_repository(repository)
   end
 
   before do
     expect(Feature.active?(:active_feature)).to be_truthy
+    expect(Feature.active?(:another_active_feature)).to be_truthy
     expect(Feature.active?(:deactive_feature)).to be_falsey
     expect(Feature.active?(:another_deactive_feature)).to be_falsey
   end
 
   after do
     expect(Feature.active?(:active_feature)).to be_truthy
+    expect(Feature.active?(:another_active_feature)).to be_truthy
     expect(Feature.active?(:deactive_feature)).to be_falsey
     expect(Feature.active?(:another_deactive_feature)).to be_falsey
   end
@@ -39,6 +42,13 @@ describe 'Feature testing support' do
     it 'deactivates an activated feature' do
       Feature.run_with_deactivated(:active_feature) do
         expect(Feature.active?(:active_feature)).to be_falsey
+      end
+    end
+
+    it 'deactivates multiple activated features' do
+      Feature.run_with_deactivated(:active_feature, :another_active_feature) do
+        expect(Feature.active?(:active_feature)).to be_falsey
+        expect(Feature.active?(:another_active_feature)).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Allow `Feature.run_with_activated` and `Feature.run_with_deactivated` accept a list of features rather than just one.
