### PR TITLE
Remove jruby and 1.9.3 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ rvm:
   - ruby-head
   - 2.1
   - 2.0.0
-  - 1.9.3
   - jruby-head
-  - jruby
   - rbx-2
 matrix:
   allow_failures:


### PR DESCRIPTION
The `mutant` gem [specifies Ruby >= 2.0.0](https://github.com/mbj/mutant/blob/75164ba31a9129fc16d27d7f4a3e741a90da4a12/mutant.gemspec#L24) which is causing [the build to fail](https://travis-ci.org/mgsnova/feature/builds/43925223).
