### PR TITLE
Fixing an issue with Feature.run_with_activated if @active_features is nil.

### DIFF
--- a/lib/feature/testing.rb
+++ b/lib/feature/testing.rb
@@ -14,6 +14,7 @@ module Feature
   #     # your test code here
   #   end
   def self.run_with_activated(*features)
+    @active_features = [] if @active_features.nil?
     old_features = @active_features.dup
     old_auto_refresh = @auto_refresh
     @active_features.concat(features).uniq!
@@ -31,6 +32,7 @@ module Feature
   #     # your test code here
   #   end
   def self.run_with_deactivated(*features)
+    @active_features = [] if @active_features.nil?
     old_features = @active_features.dup
     old_auto_refresh = @auto_refresh
     @active_features -= features

--- a/spec/feature/testing_spec.rb
+++ b/spec/feature/testing_spec.rb
@@ -69,4 +69,23 @@ describe 'Feature testing support' do
 
     it_behaves_like 'a testable repository'
   end
+
+  context 'with no features activated' do
+    before(:all) do
+      repository = Feature::Repository::SimpleRepository.new
+      Feature.set_repository(repository)
+    end
+
+    describe '.run_with_activated' do
+      it 'should not raise an error' do
+        expect { Feature.run_with_activated(:foo) {} }.to_not raise_error
+      end
+    end
+
+    describe '.run_with_deactivated' do
+      it 'should not raise an error' do
+        expect { Feature.run_with_deactivated(:foo) {} }.to_not raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
I ran into an issue with using `Feature.run_with_activated` in my rspec tests and running a single rspec test.

Description of the issue:
1. If I run my entire rspec suite, everything works fine.
2. If I run just one rspec test, the feature gem will throw an exception:

~~~
Failures:

  1) TrackerController#show should not include mixpanel gon data if send_track_events_to_mixpanel is disabled
     Failure/Error: Feature.run_with_deactivated(:send_track_events_to_mixpanel) do
     TypeError:
       can't dup NilClass
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/bundler/gems/feature-252dd4d249b7/lib/feature/testing.rb:36:in `dup'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/bundler/gems/feature-252dd4d249b7/lib/feature/testing.rb:36:in `run_with_deactivated'
     # ./spec/controllers/tracker_controller_spec.rb:101:in `block (5 levels) in <top (required)>'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:148:in `instance_exec'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:148:in `block in run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:210:in `call'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:210:in `block (2 levels) in <class:Procsy>'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-rails-3.0.1/lib/rspec/rails/example/controller_example_group.rb:174:in `block (2 levels) in <module:ControllerExampleGroup>'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:294:in `instance_exec'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:294:in `instance_exec'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/hooks.rb:430:in `block (2 levels) in run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:210:in `call'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:210:in `block (2 levels) in <class:Procsy>'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-rails-3.0.1/lib/rspec/rails/adapters.rb:68:in `block (2 levels) in <module:MinitestLifecycleAdapter>'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:294:in `instance_exec'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:294:in `instance_exec'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/hooks.rb:430:in `block (2 levels) in run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:210:in `call'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:210:in `block (2 levels) in <class:Procsy>'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/hooks.rb:428:in `run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/hooks.rb:485:in `run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:303:in `with_around_example_hooks'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example.rb:145:in `run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:494:in `block in run_examples'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:490:in `map'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:490:in `run_examples'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:457:in `run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:458:in `block in run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:458:in `map'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:458:in `run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:458:in `block in run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:458:in `map'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:458:in `run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:458:in `block in run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:458:in `map'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/example_group.rb:458:in `run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:112:in `block (2 levels) in run_specs'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:112:in `map'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/reporter.rb:54:in `report'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:108:in `run_specs'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:86:in `run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:70:in `run'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:38:in `invoke'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/gems/rspec-core-3.0.2/exe/rspec:4:in `<top (required)>'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/bin/rspec:23:in `load'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/bin/rspec:23:in `<main>'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/bin/ruby_executable_hooks:15:in `eval'
     # /Users/tout/.rvm/gems/ruby-1.9.3-p484@tesla/bin/ruby_executable_hooks:15:in `<main>'
~~~

It is blowing up because `@active_features` is `nil`.

I created a failing test in this pull request, but there is one minor wrinkle.  If you run the entire Feature rspec suite, the "failing test" won't fail.  It will only fail if you run just the test I added:

~~~
# comment out lib/feature/testing.rb:17 (which is my fix)

tom:~/workspace/feature (testing_individual_spec)$ bundle exec rspec spec/feature/testing_spec.rb:80
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options: include {:locations=>{"./spec/feature/testing_spec.rb"=>[80]}}
F

Failures:

  1) Feature testing support with no features activated .run_with_activated should not raise an error
     Failure/Error: expect { Feature.run_with_activated(:foo) {} }.to_not raise_error
       expected no Exception, got #<TypeError: can't dup NilClass> with backtrace:
         # ./lib/feature/testing.rb:18:in `dup'
         # ./lib/feature/testing.rb:18:in `run_with_activated'
         # ./spec/feature/testing_spec.rb:81:in `block (5 levels) in <top (required)>'
         # ./spec/feature/testing_spec.rb:81:in `block (4 levels) in <top (required)>'
     # ./spec/feature/testing_spec.rb:81:in `block (4 levels) in <top (required)>'

Finished in 0.00267 seconds (files took 0.39322 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/feature/testing_spec.rb:80 # Feature testing support with no features activated .run_with_activated should not raise an error
~~~

My initial hunch is that is "ok", but if you want to make the rspec suite more complex where this test runs in isolation (either a seperate test run, or I force @active_features to be nil), I can look into that too.