### PR TITLE
Rspec Integration: activate entire context group

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,41 @@ With this approach Feature is higly configurable and not bound to a specific kin
         Feature.run_with_deactivated(:feature, :another_feature) do
           # your test code
         end
+        
+    * RSpec
+        
+        # rails_helper.rb (or spec_helper.rb)
+        require 'feature/testing'
+        
+        RSpec.configure do |config|
+          config.around(:example) do |example|
+            active, inactive = example.metadata[:active], example.metadata[:inactive]
+
+            if active.present? && inactive.present?
+              Feature.run_with_activated(*active) { Feature.run_with_deactivated(*inactive) { example.run } }
+            elsif active.present?
+              Feature.run_with_activated(*active) { example.run }
+            elsif inactive.present?
+              Feature.run_with_deactivated(*inactive) { example.run }
+            else
+              example.run
+            end
+          end
+        end
+        
+        # in your test, you can use the Feature methods directly
+        it "should enable my feature" do
+          Feature.run_with_activated(:feature) do
+            expect(foo).to eq("bar")
+          end
+        end
+        
+        # in your test, you can use RSpec metadata
+        describe "feature is enabled", active: :feature do
+          it "should enable my feature" do
+            expect(foo).to eq("bar")
+          end
+        end
 
 * Feature-toggle caching
 

--- a/README.md
+++ b/README.md
@@ -64,38 +64,38 @@ With this approach Feature is higly configurable and not bound to a specific kin
         
     * RSpec
         
-        # rails_helper.rb (or spec_helper.rb)
-        require 'feature/testing'
+            # rails_helper.rb (or spec_helper.rb)
+            require 'feature/testing'
         
-        RSpec.configure do |config|
-          config.around(:example) do |example|
-            active, inactive = example.metadata[:active], example.metadata[:inactive]
+            RSpec.configure do |config|
+              config.around(:example) do |example|
+                active, inactive = example.metadata[:active], example.metadata[:inactive]
 
-            if active.present? && inactive.present?
-              Feature.run_with_activated(*active) { Feature.run_with_deactivated(*inactive) { example.run } }
-            elsif active.present?
-              Feature.run_with_activated(*active) { example.run }
-            elsif inactive.present?
-              Feature.run_with_deactivated(*inactive) { example.run }
-            else
-              example.run
+                if active.present? && inactive.present?
+                  Feature.run_with_activated(*active) { Feature.run_with_deactivated(*inactive) { example.run } }
+                elsif active.present?
+                  Feature.run_with_activated(*active) { example.run }
+                elsif inactive.present?
+                  Feature.run_with_deactivated(*inactive) { example.run }
+                else
+                  example.run
+                end
+              end
             end
-          end
-        end
         
-        # in your test, you can use the Feature methods directly
-        it "should enable my feature" do
-          Feature.run_with_activated(:feature) do
-            expect(foo).to eq("bar")
-          end
-        end
+            # in your test, you can use the Feature methods directly
+            it "should enable my feature" do
+              Feature.run_with_activated(:feature) do
+                expect(foo).to eq("bar")
+              end
+            end
         
-        # in your test, you can use RSpec metadata
-        describe "feature is enabled", active: :feature do
-          it "should enable my feature" do
-            expect(foo).to eq("bar")
-          end
-        end
+            # in your test, you can use RSpec metadata
+            describe "feature is enabled", active: :feature do
+              it "should enable my feature" do
+                expect(foo).to eq("bar")
+              end
+            end
 
 * Feature-toggle caching
 


### PR DESCRIPTION
Using `Feature.run_with_activated` is helpful for one-off tests, but can get repetitive when you have many tests which all need the same toggle state.

At first I tried this:

~~~
Feature.run_with_activated(:foo) do
  context "foo is activated" do
    it "should bar"
    it "should baz"
  end
end
~~~

But that doesn't work because the `Feature.run_with_activated` will be run at file parse time, not at spec runtime - which totally makes sense.

A technique which does work is utilizing "rspec metadata" with a custom `around` filter:
~~~
context "foo is activated", active: :foo do
  it "should bar"
  it "should baz"
end
~~~

~~~
  config.around(:example) do |example|
    active, inactive = example.metadata[:active], example.metadata[:inactive]

    if active.present? && inactive.present?
      Feature.run_with_activated(*active) { Feature.run_with_deactivated(*inactive) { example.run } }
    elsif active.present?
      Feature.run_with_activated(*active) { example.run }
    elsif inactive.present?
      Feature.run_with_deactivated(*inactive) { example.run }
    else
      example.run
    end
  end
~~~

This pull request has this information (including the around filter definition) in the README, but it might be better for me to move it into a codebase.  I could put it in it's own gem or in `feature/rspec`.  @mgsnova, what are your thoughts?