### PR TITLE
standardized the api of repositories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,14 @@
 source 'https://rubygems.org'
 
-gem 'rake'
+
+gemspec
 
 group :test do
-  gem 'rspec'
-  gem 'rspec-mocks'
   gem 'coveralls', require: false
   gem 'rubocop', require: false
-  gem 'fakeredis'
+  gem "rspec"
+  gem "rspec-mocks"
+  gem "fakeredis"
   if RUBY_VERSION >= '2.1'
     gem 'mutant'
     gem 'mutant-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 
-gemspec
+gem "rake"
 
 group :test do
   gem 'coveralls', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,13 @@
 source 'https://rubygems.org'
 
-
-gem "rake"
+gem 'rake'
 
 group :test do
   gem 'coveralls', require: false
   gem 'rubocop', require: false
-  gem "rspec"
-  gem "rspec-mocks"
-  gem "fakeredis"
+  gem 'rspec'
+  gem 'rspec-mocks'
+  gem 'fakeredis'
   if RUBY_VERSION >= '2.1'
     gem 'mutant'
     gem 'mutant-rspec'

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ With this approach Feature is highly configurable and not bound to a specific ki
         end
 
         # this returns value_true if :feature_name is active, otherwise value_false
-        Feature.switch(:feature_name, value_true, value_false) 
+        Feature.switch(:feature_name, value_true, value_false)
 
         # switch may also take Procs that will be evaluated and it's result returned.
         Feature.switch(:feature_name, -> { code... }, -> { code... })
@@ -72,12 +72,12 @@ With this approach Feature is highly configurable and not bound to a specific ki
 
     * By default, Feature will lazy-load the active features from the
       underlying repository the first time you try to check whether a
-      feature is set or not. 
+      feature is set or not.
 
     * Subsequent calls to Feature will access the cached in-memory
-      representation of the list of features. So changes to toggles in the 
+      representation of the list of features. So changes to toggles in the
       underlying repository would not be reflected in the application
-      until you restart the application or manally call 
+      until you restart the application or manally call
 
             Feature.refresh!
 
@@ -85,7 +85,39 @@ With this approach Feature is highly configurable and not bound to a specific ki
       set_repository, to force Feature to auto-refresh the feature list
       on every feature-toggle check you make.
 
-            Feature.set_repository(your_repository, true) 
+            Feature.set_repository(your_repository, true)
+
+## How to read current features
+
+* get the value of a feature
+
+        Feature.get(:feature_name) # => true or false depending on if it is active or not
+
+* list the names of all defined features
+
+        Feature.list # => list of all feature names
+
+## How to add/update/remove current features
+Note: Only works for dynamic repositories (aka, excludes YamlRepository)
+* set the value of a feature to active
+
+        Feature.set(:my_feature, true) # returns true if successful
+
+* set the value of a feature to inactive
+
+        Feature.set(:my_feature, false) # returns true if successful
+
+* add an active feature
+
+        Feature.add(:my_feature, true) # returns true if successful
+
+* add an inactive feature
+
+        Feature.add(:my_feature, false) # returns true if successful
+
+* remove a feature
+
+        Feature.remove(:my_feature) # returns true if successful
 
 ## How to setup different backends
 
@@ -98,7 +130,6 @@ With this approach Feature is highly configurable and not bound to a specific ki
         require 'feature'
 
         repo = Feature::Repository::SimpleRepository.new
-        repo.add_active_feature :be_nice
 
         Feature.set_repository repo
 
@@ -113,13 +144,12 @@ With this approach Feature is highly configurable and not bound to a specific ki
         # setup code (or Rails initializer: config/initializers/feature.rb)
         require 'feature'
 
-        # "feature_toggles" will be the key name in redis
-        repo = Feature::Repository::RedisRepository.new("feature_toggles")
-        Feature.set_repository repo
+        redis = Redis.current # Or any other instance of a redis client which supports hset, hget, hdel, and hgetall
 
-        # add/toggle features in Redis
-        Redis.current.hset("feature_toggles", "ActiveFeature", true)
-        Redis.current.hset("feature_toggles", "InActiveFeature", false)
+        # "feature_toggles" will be the key name in redis
+        # if no redis client instance is provided, defaults to Redis.current
+        repo = Feature::Repository::RedisRepository.new("feature_toggles", redis)
+        Feature.set_repository repo
 
 ### YamlRepository (features configured in static yml file)
 

--- a/feature.gemspec
+++ b/feature.gemspec
@@ -12,6 +12,4 @@ Gem::Specification.new do |s|
   s.summary = 'Feature Toggle library for ruby'
   s.files = FileList['{lib,spec}/**/*'].exclude('rdoc').to_a + ['Rakefile', 'Gemfile', 'README.md', 'CHANGELOG.md']
   s.license = 'MIT'
-
-  s.add_dependency "rake"
 end

--- a/feature.gemspec
+++ b/feature.gemspec
@@ -2,7 +2,7 @@ require 'rubygems/package_task'
 
 Gem::Specification.new do |s|
   s.name = 'feature'
-  s.version = '1.3.0'
+  s.version = '1.4.0'
 
   s.authors = ['Markus Gerdes']
   s.email = 'github@mgsnova.de'
@@ -12,4 +12,6 @@ Gem::Specification.new do |s|
   s.summary = 'Feature Toggle library for ruby'
   s.files = FileList['{lib,spec}/**/*'].exclude('rdoc').to_a + ['Rakefile', 'Gemfile', 'README.md', 'CHANGELOG.md']
   s.license = 'MIT'
+
+  s.add_dependency "rake"
 end

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -43,6 +43,10 @@ module Feature
     @repository.remove_feature(feature)
   end
 
+  def self.list
+    @repository.list_features
+  end
+
   # Set the feature repository
   # The given repository has to respond to method 'active_features' with an array of symbols
   #

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -1,3 +1,4 @@
+require 'feature/tasks'
 # Feature module provides all methods
 # - to set a feature repository
 # - to check if a feature (represented by a symbol) is active or inactive
@@ -43,7 +44,7 @@ module Feature
     @repository.remove_feature(feature)
   end
 
-  def self.list
+  def self.all
     @repository.features
   end
 

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -27,6 +27,22 @@ module Feature
   @repository = nil
   @active_features = nil
 
+  def self.get(feature)
+    @repository.get_feature(feature)
+  end
+
+  def self.set(feature, active)
+    @repository.set_feature(feature, active)
+  end
+
+  def self.add(feature, active)
+    @repository.create_feature(feature, active)
+  end
+
+  def self.remove(feature)
+    @repository.remove_feature(feature)
+  end
+
   # Set the feature repository
   # The given repository has to respond to method 'active_features' with an array of symbols
   #

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -44,7 +44,7 @@ module Feature
   end
 
   def self.list
-    @repository.list_features
+    @repository.features
   end
 
   # Set the feature repository

--- a/lib/feature/repository/active_record_repository.rb
+++ b/lib/feature/repository/active_record_repository.rb
@@ -16,12 +16,12 @@ module Feature
         @model = model
       end
 
-      # Returns list of active features
+      # Add an inactive feature to repository
       #
-      # @return [Array<Symbol>] list of active features
+      # @param [Symbol] feature the feature to be added
       #
-      def active_features
-        @model.where(active: true).map { |f| f.name.to_sym }
+      def add_inactive_feature(feature)
+        create_feature(feature, false)
       end
 
       # Add an active feature to repository
@@ -29,9 +29,70 @@ module Feature
       # @param [Symbol] feature the feature to be added
       #
       def add_active_feature(feature)
+        create_feature(feature, true)
+      end
+
+      # Remove a feature from a repository
+      #
+      # @param [Symbol] feature the feature to be removed
+      #
+      def remove_feature(feature)
+        feature_obj = @model.find_by_name(feature.to_s)
+        feature_obj.destroy! if feature_obj.present?
+      end
+
+      # Get the value of feature from a repository
+      #
+      # @param [Symbol] feature the feature to be checked
+      # @return [Boolean] whether the feature is active
+      def get_feature(feature)
+        check_feature_is_not_symbol(feature)
+        @model.find_by_name(feature.to_s).active
+      end
+
+      # Add a feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def create_feature(feature, val)
         check_feature_is_not_symbol(feature)
         check_feature_already_in_list(feature)
-        @model.create!(name: feature.to_s, active: true)
+        @model.create!({name: feature.to_s, active: val}, without_protection: :true)
+      end
+
+      # Set the value of feature in a repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def set_feature(feature, val)
+        feature_obj = @model.find_by_name(feature.to_s)
+        return create_feature(feature, val) if feature_obj.nil?
+        feature_obj.active = val
+        feature_obj.save!
+      end
+
+      # List all of the features in a repository
+      #
+      # @return [Array<Symbol>] list of all features
+      #
+      def list_features
+        @model.pluck(:name).map(&:to_sym)
+      end
+
+      # Returns list of active features
+      #
+      # @return [Array<Symbol>] list of active features
+      #
+      def active_features
+        @model.where(active: true).map {|f| f.name.to_sym }
+      end
+
+      # Returns list of inactive features
+      #
+      # @return [Array<Symbol>] list of inactive features
+      #
+      def inactive_features
+        @model.where(active: false).map {|f| f.name.to_sym }
       end
 
       # Checks if the given feature is a not symbol and raises an exception if so
@@ -43,13 +104,13 @@ module Feature
       end
       private :check_feature_is_not_symbol
 
-      # Checks if given feature is already added to list of active features
+      # Checks if given feature is already added to list of all features
       # and raises an exception if so
       #
       # @param [Symbol] feature the feature to be checked
       #
       def check_feature_already_in_list(feature)
-        fail ArgumentError, "feature :#{feature} already added" if @model.exists?(feature.to_s)
+        fail ArgumentError, "feature :#{feature} already added" if @model.exists?(name: feature.to_s)
       end
       private :check_feature_already_in_list
     end

--- a/lib/feature/repository/active_record_repository.rb
+++ b/lib/feature/repository/active_record_repository.rb
@@ -68,7 +68,7 @@ module Feature
       # @return [Array<Symbol>] list of all features
       #
       def features
-        @model.pluck(:name).map(&:to_sym)
+        @model.all.inject({}) { |a, e| a.merge(e.name.to_sym => e.active) }
       end
 
       # Returns list of active features

--- a/lib/feature/repository/active_record_repository.rb
+++ b/lib/feature/repository/active_record_repository.rb
@@ -57,7 +57,7 @@ module Feature
       def create_feature(feature, val)
         check_feature_is_not_symbol(feature)
         check_feature_already_in_list(feature)
-        @model.create!({name: feature.to_s, active: val}, without_protection: :true)
+        @model.create!({ name: feature.to_s, active: val }, without_protection: :true)
       end
 
       # Set the value of feature in a repository
@@ -84,7 +84,7 @@ module Feature
       # @return [Array<Symbol>] list of active features
       #
       def active_features
-        @model.where(active: true).map {|f| f.name.to_sym }
+        @model.where(active: true).map { |f| f.name.to_sym }
       end
 
       # Returns list of inactive features
@@ -92,7 +92,7 @@ module Feature
       # @return [Array<Symbol>] list of inactive features
       #
       def inactive_features
-        @model.where(active: false).map {|f| f.name.to_sym }
+        @model.where(active: false).map { |f| f.name.to_sym }
       end
 
       # Checks if the given feature is a not symbol and raises an exception if so

--- a/lib/feature/repository/active_record_repository.rb
+++ b/lib/feature/repository/active_record_repository.rb
@@ -16,14 +16,6 @@ module Feature
         @model = model
       end
 
-      # Add an inactive feature to repository
-      #
-      # @param [Symbol] feature the feature to be added
-      #
-      def add_inactive_feature(feature)
-        create_feature(feature, false)
-      end
-
       # Add an active feature to repository
       #
       # @param [Symbol] feature the feature to be added
@@ -75,7 +67,7 @@ module Feature
       #
       # @return [Array<Symbol>] list of all features
       #
-      def list_features
+      def features
         @model.pluck(:name).map(&:to_sym)
       end
 

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -10,11 +10,12 @@ module Feature
     # the Redis hash that will store all of your feature toggles.
     #
     class RedisRepository
+      attr_accessor :redis
       # Constructor
       #
       # @param redis_key the key of the redis hash where all the toggles will be stored
       #
-      def initialize(redis_key, redis=nil)
+      def initialize(redis_key, redis = nil)
         @redis_key = redis_key
         self.redis = redis unless redis.nil?
       end
@@ -93,10 +94,6 @@ module Feature
         redis.hgetall(@redis_key).select { |_k, v| v.to_s == 'false' }.map { |k, _v| k.to_sym }
       end
 
-      def redis=(server)
-        @redis = server
-      end
-
       def redis
         @redis ||= Redis.current
       end
@@ -123,9 +120,9 @@ module Feature
       # Converts "true" to true and "false" || nil to false
       #
       # @param [String] "true" or "false"
-      def convert_string_to_bool str
-        return true if str == "true"
-        return false if str.nil? || str == "false"
+      def convert_string_to_bool(str)
+        return true if str == 'true'
+        return false if str.nil? || str == 'false'
         fail ArgumentError, "invalid bool string: #{str.inspect}"
       end
       private :convert_string_to_bool

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -20,14 +20,6 @@ module Feature
         self.redis = redis unless redis.nil?
       end
 
-      # Add an inactive feature to repository
-      #
-      # @param [Symbol] feature the feature to be added
-      #
-      def add_inactive_feature(feature)
-        create_feature(feature, false)
-      end
-
       # Add an active feature to repository
       #
       # @param [Symbol] feature the feature to be added
@@ -74,7 +66,7 @@ module Feature
       #
       # @return [Array<Symbol>] list of all features
       #
-      def list_features
+      def features
         redis.hkeys(@redis_key).map(&:to_sym)
       end
 

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -14,16 +14,17 @@ module Feature
       #
       # @param redis_key the key of the redis hash where all the toggles will be stored
       #
-      def initialize(redis_key)
+      def initialize(redis_key, redis=nil)
         @redis_key = redis_key
+        self.redis = redis unless redis.nil?
       end
 
-      # Returns list of active features
+      # Add an inactive feature to repository
       #
-      # @return [Array<Symbol>] list of active features
+      # @param [Symbol] feature the feature to be added
       #
-      def active_features
-        Redis.current.hgetall(@redis_key).select { |_k, v| v.to_s == 'true' }.map { |k, _v| k.to_sym }
+      def add_inactive_feature(feature)
+        create_feature(feature, false)
       end
 
       # Add an active feature to repository
@@ -31,9 +32,73 @@ module Feature
       # @param [Symbol] feature the feature to be added
       #
       def add_active_feature(feature)
+        create_feature(feature, true)
+      end
+
+      # Remove a feature from a repository
+      #
+      # @param [Symbol] feature the feature to be removed
+      #
+      def remove_feature(feature)
+        redis.hdel(@redis_key, feature) == 1
+      end
+
+      # Get the value of feature from a repository
+      #
+      # @param [Symbol] feature the feature to be checked
+      # @return [Boolean] whether the feature is active
+      def get_feature(feature)
+        convert_string_to_bool(redis.hget(@redis_key, feature.to_s))
+      end
+
+      # Add a feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def create_feature(feature, val)
         check_feature_is_not_symbol(feature)
         check_feature_already_in_list(feature)
-        Redis.current.hset(@redis_key, feature, true)
+        set_feature(feature, val)
+      end
+
+      # Set the value of feature in a repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def set_feature(feature, val)
+        redis.hset(@redis_key, feature.to_s, val)
+      end
+
+      # List all of the features in a repository
+      #
+      # @return [Array<Symbol>] list of all features
+      #
+      def list_features
+        redis.hkeys(@redis_key).map(&:to_sym)
+      end
+
+      # Returns list of active features
+      #
+      # @return [Array<Symbol>] list of active features
+      #
+      def active_features
+        redis.hgetall(@redis_key).select { |_k, v| v.to_s == 'true' }.map { |k, _v| k.to_sym }
+      end
+
+      # Returns list of inactive features
+      #
+      # @return [Array<Symbol>] list of inactive features
+      #
+      def inactive_features
+        redis.hgetall(@redis_key).select { |_k, v| v.to_s == 'false' }.map { |k, _v| k.to_sym }
+      end
+
+      def redis=(server)
+        @redis = server
+      end
+
+      def redis
+        @redis ||= Redis.current
       end
 
       # Checks that given feature is a symbol, raises exception otherwise
@@ -51,9 +116,19 @@ module Feature
       # @param [Symbol] feature the feature to be checked
       #
       def check_feature_already_in_list(feature)
-        fail ArgumentError, "feature :#{feature} already added" if Redis.current.hexists(@redis_key, feature)
+        fail ArgumentError, "feature :#{feature} already added" if redis.hexists(@redis_key, feature)
       end
       private :check_feature_already_in_list
+
+      # Converts "true" to true and "false" || nil to false
+      #
+      # @param [String] "true" or "false"
+      def convert_string_to_bool str
+        return true if str == "true"
+        return false if str.nil? || str == "false"
+        fail ArgumentError, "invalid bool string: #{str.inspect}"
+      end
+      private :convert_string_to_bool
     end
   end
 end

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -40,7 +40,7 @@ module Feature
       # @param [Symbol] feature the feature to be removed
       #
       def remove_feature(feature)
-        redis.hdel(@redis_key, feature) == 1
+        redis.hdel(@redis_key, feature.to_s) == 1
       end
 
       # Get the value of feature from a repository

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -15,9 +15,9 @@ module Feature
       #
       # @param redis_key the key of the redis hash where all the toggles will be stored
       #
-      def initialize(redis_key, redis = nil)
+      def initialize(redis_key, server = nil)
         @redis_key = redis_key
-        self.redis = redis unless redis.nil?
+        self.redis = server unless redis.nil?
       end
 
       # Add an active feature to repository

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -67,7 +67,7 @@ module Feature
       # @return [Array<Symbol>] list of all features
       #
       def features
-        redis.hkeys(@redis_key).map(&:to_sym)
+        redis.hgetall(@redis_key).inject({}) { |h, (k, v)| h.merge(k.to_sym => convert_string_to_bool(v)) }
       end
 
       # Returns list of active features

--- a/lib/feature/repository/simple_repository.rb
+++ b/lib/feature/repository/simple_repository.rb
@@ -17,14 +17,6 @@ module Feature
         @inactive_features = []
       end
 
-      # Add an inactive feature to repository
-      #
-      # @param [Symbol] feature the feature to be added
-      #
-      def add_inactive_feature(feature)
-        create_feature(feature, false)
-      end
-
       # Add an active feature to repository
       #
       # @param [Symbol] feature the feature to be added
@@ -74,7 +66,7 @@ module Feature
       #
       # @return [Array<Symbol>] list of all features
       #
-      def list_features
+      def features
         active_features + inactive_features
       end
 
@@ -109,7 +101,7 @@ module Feature
       # @param [Symbol] feature the feature to be checked
       #
       def check_feature_already_in_list(feature)
-        fail ArgumentError, "feature :#{feature} already added" if list_features.include?(feature)
+        fail ArgumentError, "feature :#{feature} already added" if features.include?(feature)
       end
       private :check_feature_already_in_list
     end

--- a/lib/feature/repository/simple_repository.rb
+++ b/lib/feature/repository/simple_repository.rb
@@ -14,6 +14,68 @@ module Feature
       #
       def initialize
         @active_features = []
+        @inactive_features = []
+      end
+
+      # Add an inactive feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def add_inactive_feature(feature)
+        create_feature(feature, false)
+      end
+
+      # Add an active feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def add_active_feature(feature)
+        create_feature(feature, true)
+      end
+
+      # Remove a feature from a repository
+      #
+      # @param [Symbol] feature the feature to be removed
+      #
+      def remove_feature(feature)
+        @active_features -= [feature]
+        @inactive_features -= [feature]
+        true
+      end
+
+      # Get the value of feature from a repository
+      #
+      # @param [Symbol] feature the feature to be checked
+      # @return [Boolean] whether the feature is active
+      def get_feature(feature)
+        @active_features.include?(feature)
+      end
+
+      # Add a feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def create_feature(feature, val)
+        check_feature_is_not_symbol(feature)
+        check_feature_already_in_list(feature)
+        val ? (@active_features << feature) : (@inactive_features << feature)
+      end
+
+      # Set the value of feature in a repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def set_feature(feature, val)
+        remove_feature(feature)
+        create_feature(feature, val)
+      end
+
+      # List all of the features in a repository
+      #
+      # @return [Array<Symbol>] list of all features
+      #
+      def list_features
+        active_features + inactive_features
       end
 
       # Returns list of active features
@@ -24,14 +86,12 @@ module Feature
         @active_features.dup
       end
 
-      # Add an active feature to repository
+      # Returns list of inactive features
       #
-      # @param [Symbol] feature the feature to be added
+      # @return [Array<Symbol>] list of inactive features
       #
-      def add_active_feature(feature)
-        check_feature_is_not_symbol(feature)
-        check_feature_already_in_list(feature)
-        @active_features << feature
+      def inactive_features
+        @inactive_features.dup
       end
 
       # Checks that given feature is a symbol, raises exception otherwise
@@ -49,7 +109,7 @@ module Feature
       # @param [Symbol] feature the feature to be checked
       #
       def check_feature_already_in_list(feature)
-        fail ArgumentError, "feature :#{feature} already added" if @active_features.include?(feature)
+        fail ArgumentError, "feature :#{feature} already added" if list_features.include?(feature)
       end
       private :check_feature_already_in_list
     end

--- a/lib/feature/repository/simple_repository.rb
+++ b/lib/feature/repository/simple_repository.rb
@@ -67,7 +67,9 @@ module Feature
       # @return [Array<Symbol>] list of all features
       #
       def features
-        active_features + inactive_features
+        active = active_features.inject({}) { |a, e| a.merge(e => true) }
+        inactive = inactive_features.inject({}) { |a, e| a.merge(e => false) }
+        active.merge(inactive)
       end
 
       # Returns list of active features

--- a/lib/feature/repository/yaml_repository.rb
+++ b/lib/feature/repository/yaml_repository.rb
@@ -51,7 +51,7 @@ module Feature
       #
       def active_features
         data_hash = get_feature_hash(read_file(@yaml_file_name), @environment)
-        data_hash.select { |_,v| v }.keys.map(&:to_sym)
+        data_hash.select { |_, v| v }.keys.map(&:to_sym)
       end
 
       # Returns list of inactive features
@@ -60,7 +60,7 @@ module Feature
       #
       def inactive_features
         data_hash = get_feature_hash(read_file(@yaml_file_name), @environment)
-        data_hash.select { |_,v| !v }.keys.map(&:to_sym)
+        data_hash.select { |_, v| !v }.keys.map(&:to_sym)
       end
 
       # Returns list of all features

--- a/lib/feature/repository/yaml_repository.rb
+++ b/lib/feature/repository/yaml_repository.rb
@@ -69,7 +69,7 @@ module Feature
       #
       def features
         data_hash = get_feature_hash(read_file(@yaml_file_name), @environment)
-        data_hash.keys.map(&:to_sym)
+        data_hash.each_pair.inject({}) { |h, (k, v)| h.merge(k.to_sym => v) }
       end
 
       # Read given file, perform erb evaluation and yaml parsing

--- a/lib/feature/repository/yaml_repository.rb
+++ b/lib/feature/repository/yaml_repository.rb
@@ -67,7 +67,7 @@ module Feature
       #
       # @return [Array<Symbol>] list of active features
       #
-      def list_features
+      def features
         data_hash = get_feature_hash(read_file(@yaml_file_name), @environment)
         data_hash.keys.map(&:to_sym)
       end

--- a/lib/feature/repository/yaml_repository.rb
+++ b/lib/feature/repository/yaml_repository.rb
@@ -36,13 +36,40 @@ module Feature
         @environment = environment
       end
 
+      # Get the value of feature from a repository
+      #
+      # @param [Symbol] feature the feature to be checked
+      # @return [Boolean] whether the feature is active
+      #
+      def get_feature(feature)
+        active_features.include?(feature)
+      end
+
       # Returns list of active features
       #
       # @return [Array<Symbol>] list of active features
       #
       def active_features
-        data = read_file(@yaml_file_name)
-        get_active_features(data, @environment)
+        data_hash = get_feature_hash(read_file(@yaml_file_name), @environment)
+        data_hash.select { |_,v| v }.keys.map(&:to_sym)
+      end
+
+      # Returns list of inactive features
+      #
+      # @return [Array<Symbol>] list of active features
+      #
+      def inactive_features
+        data_hash = get_feature_hash(read_file(@yaml_file_name), @environment)
+        data_hash.select { |_,v| !v }.keys.map(&:to_sym)
+      end
+
+      # Returns list of all features
+      #
+      # @return [Array<Symbol>] list of active features
+      #
+      def list_features
+        data_hash = get_feature_hash(read_file(@yaml_file_name), @environment)
+        data_hash.keys.map(&:to_sym)
       end
 
       # Read given file, perform erb evaluation and yaml parsing
@@ -57,25 +84,25 @@ module Feature
       end
       private :read_file
 
-      # Extracts active features from given hash
+      # Extracts features hash from given yaml
       #
       # @param data [Hash] hash parsed from yaml file
       # @param selector [String] uses the value for this key as source of feature data
       #
-      def get_active_features(data, selector)
+      def get_feature_hash(data, selector)
         data = data[selector] unless selector.empty?
 
         if !data.is_a?(Hash) || !data.key?('features')
           fail ArgumentError, 'yaml config does not contain proper config'
         end
 
-        return [] unless data['features']
+        return {} unless data['features']
 
         check_valid_feature_data(data['features'])
 
-        data['features'].keys.select { |key| data['features'][key] }.map(&:to_sym)
+        data['features']
       end
-      private :get_active_features
+      private :get_feature_hash
 
       # Checks for valid values in given feature hash
       #

--- a/lib/feature/tasks.rb
+++ b/lib/feature/tasks.rb
@@ -1,8 +1,9 @@
 if defined?(Rails::Railtie)
   module Feature
+    # Railtie class used to autoload rake tasks into rails projects when available
     class AddTasks < Rails::Railtie
       rake_tasks do
-        paths = Dir[File.join(File.dirname(File.dirname(__FILE__)),'tasks/*.rake')]
+        paths = Dir[File.join(File.dirname(File.dirname(__FILE__)), 'tasks/*.rake')]
         paths.each { |f| load f }
       end
     end

--- a/lib/feature/tasks.rb
+++ b/lib/feature/tasks.rb
@@ -1,0 +1,10 @@
+if defined?(Rails::Railtie)
+  module Feature
+    class AddTasks < Rails::Railtie
+      rake_tasks do
+        paths = Dir[File.join(File.dirname(File.dirname(__FILE__)),'tasks/*.rake')]
+        paths.each { |f| load f }
+      end
+    end
+  end
+end

--- a/lib/tasks/feature.rake
+++ b/lib/tasks/feature.rake
@@ -1,56 +1,56 @@
 namespace :features do
-  desc "list all feature toggles with their current state"
-  task :all => :environment do
+  desc 'list all feature toggles with their current state'
+  task all: :environment do
     puts Feature.all
   end
 
-  desc "enable feature toggle"
-  task :enable, [:name] => :environment do |t, args|
+  desc 'enable feature toggle'
+  task :enable, [:name] => :environment do |_t, args|
     if args[:name]
       Feature.set(args[:name].to_sym, true)
       puts "Set #{args[:name]} to active"
     else
-      puts "Usage: rake features:enable[toggle_name]"
+      puts 'Usage: rake features:enable[feature_name]'
     end
   end
 
-  desc "disable feature toggle"
-  task :disable, [:name] => :environment do |t, args|
+  desc 'disable feature toggle'
+  task :disable, [:name] => :environment do |_t, args|
     if args[:name]
       Feature.set(args[:name].to_sym, false)
       puts "Set #{args[:name]} to inactive"
     else
-      puts "Usage: rake features:disable[toggle_name]"
+      puts 'Usage: rake features:disable[feature_name]'
     end
   end
 
-  desc "delete a feature toggle"
-  task :remove, [:name] => :environment do |t, args|
+  desc 'delete a feature toggle'
+  task :remove, [:name] => :environment do |_t, args|
     if args[:name]
       Feature.delete(args[:name].to_sym)
       puts "Removed #{args[:name]}"
     else
-      puts "Usage: rake features:remove[toggle_name]"
+      puts 'Usage: rake features:remove[feature_name]'
     end
   end
 
-  desc "create an active feature toggle"
-  task :add_active, [:name] => :environment do |t, args|
+  desc 'create an active feature toggle'
+  task :add_active, [:name] => :environment do |_t, args|
     if args[:name]
       Feature.add(args[:name].to_sym, true)
       puts "Added #{args[:name]} with a value of true"
     else
-      puts "Usage: rake features:add_active[toggle_name]"
+      puts 'Usage: rake features:add_active[feature_name]'
     end
   end
 
-  desc "create an inactive feature toggle"
-  task :add_inactive, [:name] => :environment do |t, args|
+  desc 'create an inactive feature toggle'
+  task :add_inactive, [:name] => :environment do |_t, args|
     if args[:name]
       Feature.add(args[:name].to_sym, false)
       puts "Added #{args[:name]} with a value of false"
     else
-      puts "Usage: rake features:add_inactive[toggle_name]"
+      puts 'Usage: rake features:add_inactive[feature_name]'
     end
   end
 end

--- a/lib/tasks/feature.rake
+++ b/lib/tasks/feature.rake
@@ -1,0 +1,56 @@
+namespace :features do
+  desc "list all feature toggles with their current state"
+  task :all => :environment do
+    puts Feature.all
+  end
+
+  desc "enable feature toggle"
+  task :enable, [:name] => :environment do |t, args|
+    if args[:name]
+      Feature.set(args[:name].to_sym, true)
+      puts "Set #{args[:name]} to active"
+    else
+      puts "Usage: rake features:enable[toggle_name]"
+    end
+  end
+
+  desc "disable feature toggle"
+  task :disable, [:name] => :environment do |t, args|
+    if args[:name]
+      Feature.set(args[:name].to_sym, false)
+      puts "Set #{args[:name]} to inactive"
+    else
+      puts "Usage: rake features:disable[toggle_name]"
+    end
+  end
+
+  desc "delete a feature toggle"
+  task :remove, [:name] => :environment do |t, args|
+    if args[:name]
+      Feature.delete(args[:name].to_sym)
+      puts "Removed #{args[:name]}"
+    else
+      puts "Usage: rake features:remove[toggle_name]"
+    end
+  end
+
+  desc "create an active feature toggle"
+  task :add_active, [:name] => :environment do |t, args|
+    if args[:name]
+      Feature.add(args[:name].to_sym, true)
+      puts "Added #{args[:name]} with a value of true"
+    else
+      puts "Usage: rake features:add_active[toggle_name]"
+    end
+  end
+
+  desc "create an inactive feature toggle"
+  task :add_inactive, [:name] => :environment do |t, args|
+    if args[:name]
+      Feature.add(args[:name].to_sym, false)
+      puts "Added #{args[:name]} with a value of false"
+    else
+      puts "Usage: rake features:add_inactive[toggle_name]"
+    end
+  end
+end

--- a/spec/feature/active_record_repository_spec.rb
+++ b/spec/feature/active_record_repository_spec.rb
@@ -59,12 +59,25 @@ describe Feature::Repository::ActiveRecordRepository do
   end
 
   after(:each) do
-    GC.start
+    @features = nil
+    @repository = nil
+    ObjectSpace.garbage_collect
   end
 
   it_behaves_like "a dynamic repository" do
+    before(:each) do
+      # Mock the model
+      @features = FeatureToggleTest
+      @repository = ActiveRecordRepository.new(@features)
+    end
+
+    after(:each) do
+      @features = nil
+      @repository = nil
+      ObjectSpace.garbage_collect
+    end
     let(:repo) do
-      ActiveRecordRepository.new(FeatureToggleTest)
+      @repository
     end
   end
 

--- a/spec/feature/active_record_repository_spec.rb
+++ b/spec/feature/active_record_repository_spec.rb
@@ -2,28 +2,85 @@ require 'spec_helper'
 
 include Feature::Repository
 
+class FeatureToggleTest < Feature::Repository::ActiveRecordRepository
+  attr_accessor :name, :active
+
+  def initialize name, active=nil
+    self.name = name
+    self.active = active
+  end
+
+  def save!
+    true
+  end
+
+  def destroy!
+    true
+  end
+
+  def self.destroy_all
+    all.map {|o| o = nil}
+  end
+
+  def self.pluck(attribute_name)
+    all.map(&attribute_name.to_sym)
+  end
+
+  def self.where(opts)
+    all.select { |f| opts.each_pair.all? {|k, v| f.public_send(k.to_sym) == v } }
+  end
+
+  def present?
+    true
+  end
+
+  def self.find_by_name(name)
+    all.select {|f| name == f.name}.first
+  end
+
+  def self.exists?(opts)
+    !find_by_name(opts[:name]).nil?
+  end
+
+  def self.create!(params, opts={})
+    new(params[:name], params[:active])
+  end
+
+  def self.all
+    ObjectSpace.each_object(self).to_a
+  end
+end
+
 describe Feature::Repository::ActiveRecordRepository do
   before(:each) do
     # Mock the model
-    @features = double('FeatureToggle')
+    @features = FeatureToggleTest
     @repository = ActiveRecordRepository.new(@features)
   end
 
-  it 'should have no active features after initialization' do
-    allow(@features).to receive(:where) { [] }
+  after(:each) do
+    GC.start
+  end
 
+  it_behaves_like "a dynamic repository" do
+    let(:repo) do
+      ActiveRecordRepository.new(FeatureToggleTest)
+    end
+  end
+
+  it 'should have no active features after initialization' do
     expect(@repository.active_features).to eq([])
   end
 
   it 'should have active features' do
-    allow(@features).to receive(:where).with(active: true) { [double(name: 'active')] }
+    @repository.create_feature(:active, true)
 
     expect(@repository.active_features).to eq([:active])
   end
 
   it 'should add an active feature' do
-    expect(@features).to receive(:exists?).with('feature_a').and_return(false)
-    expect(@features).to receive(:create!).with(name: 'feature_a', active: true)
+    expect(@features).to receive(:exists?).with(name: 'feature_a').and_return(false)
+    expect(@features).to receive(:create!).with({name: 'feature_a', active: true}, without_protection: :true)
 
     @repository.add_active_feature :feature_a
   end
@@ -35,9 +92,6 @@ describe Feature::Repository::ActiveRecordRepository do
   end
 
   it 'should raise an exception when adding a active feature already added as active' do
-    expect(@features).to receive(:create!).with(name: 'feature_a', active: true)
-    allow(@features).to receive(:exists?).and_return(false, true)
-
     @repository.add_active_feature :feature_a
     expect do
       @repository.add_active_feature :feature_a

--- a/spec/feature/redis_repository_spec.rb
+++ b/spec/feature/redis_repository_spec.rb
@@ -7,24 +7,24 @@ describe Feature::Repository::RedisRepository do
     @repository = RedisRepository.new('application_features')
   end
 
-  it_behaves_like "a dynamic repository" do
+  it_behaves_like 'a dynamic repository' do
     let(:repo) { RedisRepository.new('application_features') }
   end
 
-  it_behaves_like "a repository" do
-    let(:repo) {
+  it_behaves_like 'a repository' do
+    let(:repo) do
       repository = RedisRepository.new('application_features')
       repository.create_feature(:feature_a_inactive, false)
       repository.create_feature(:feature_b_inactive, false)
       repository.create_feature(:feature_a_active, true)
       repository.create_feature(:feature_b_active, true)
       repository
-    }
+    end
   end
 
   let(:specified_redis) { double }
   let(:repo) { RedisRepository.new('application_features', specified_redis) }
-  it "should allow you to specify the redis instance to use" do
+  it 'should allow you to specify the redis instance to use' do
     expect(repo.redis).to eq specified_redis
   end
 end

--- a/spec/feature/redis_repository_spec.rb
+++ b/spec/feature/redis_repository_spec.rb
@@ -7,34 +7,24 @@ describe Feature::Repository::RedisRepository do
     @repository = RedisRepository.new('application_features')
   end
 
-  it 'should have no active features after initialization' do
-    expect(@repository.active_features).to eq([])
+  it_behaves_like "a dynamic repository" do
+    let(:repo) { RedisRepository.new('application_features') }
   end
 
-  it 'should add an active feature' do
-    @repository.add_active_feature :feature_a
-    expect(@repository.active_features).to eq([:feature_a])
+  it_behaves_like "a repository" do
+    let(:repo) {
+      repository = RedisRepository.new('application_features')
+      repository.create_feature(:feature_a_inactive, false)
+      repository.create_feature(:feature_b_inactive, false)
+      repository.create_feature(:feature_a_active, true)
+      repository.create_feature(:feature_b_active, true)
+      repository
+    }
   end
 
-  it 'should only show active feature' do
-    Redis.current.hset('application_features', 'inactive_a', false)
-    Redis.current.hset('application_features', 'inactive_b', false)
-    Redis.current.hset('application_features', 'feature_a', true)
-    Redis.current.hset('application_features', 'feature_b', true)
-
-    expect(@repository.active_features).to eq([:feature_a, :feature_b])
-  end
-
-  it 'should raise an exception when adding not a symbol as active feature' do
-    expect do
-      @repository.add_active_feature 'feature_a'
-    end.to raise_error(ArgumentError, 'feature_a is not a symbol')
-  end
-
-  it 'should raise an exception when adding a active feature already added as active' do
-    @repository.add_active_feature :feature_a
-    expect do
-      @repository.add_active_feature :feature_a
-    end.to raise_error(ArgumentError, 'feature :feature_a already added')
+  let(:specified_redis) { double }
+  let(:repo) { RedisRepository.new('application_features', specified_redis) }
+  it "should allow you to specify the redis instance to use" do
+    expect(repo.redis).to eq specified_redis
   end
 end

--- a/spec/feature/simple_repository_spec.rb
+++ b/spec/feature/simple_repository_spec.rb
@@ -7,6 +7,21 @@ describe Feature::Repository::SimpleRepository do
     @repository = SimpleRepository.new
   end
 
+  it_behaves_like "a dynamic repository" do
+    let(:repo) { SimpleRepository.new }
+  end
+
+  it_behaves_like "a repository" do
+    let(:repo) {
+      repository = SimpleRepository.new
+      repository.create_feature(:feature_a_inactive, false)
+      repository.create_feature(:feature_b_inactive, false)
+      repository.create_feature(:feature_a_active, true)
+      repository.create_feature(:feature_b_active, true)
+      repository
+    }
+  end
+
   it 'should have no active features after initialization' do
     expect(@repository.active_features).to eq([])
   end

--- a/spec/feature/simple_repository_spec.rb
+++ b/spec/feature/simple_repository_spec.rb
@@ -7,19 +7,19 @@ describe Feature::Repository::SimpleRepository do
     @repository = SimpleRepository.new
   end
 
-  it_behaves_like "a dynamic repository" do
+  it_behaves_like 'a dynamic repository' do
     let(:repo) { SimpleRepository.new }
   end
 
-  it_behaves_like "a repository" do
-    let(:repo) {
+  it_behaves_like 'a repository' do
+    let(:repo) do
       repository = SimpleRepository.new
       repository.create_feature(:feature_a_inactive, false)
       repository.create_feature(:feature_b_inactive, false)
       repository.create_feature(:feature_a_active, true)
       repository.create_feature(:feature_b_active, true)
       repository
-    }
+    end
   end
 
   it 'should have no active features after initialization' do

--- a/spec/feature/yaml_repository_spec.rb
+++ b/spec/feature/yaml_repository_spec.rb
@@ -12,8 +12,8 @@ describe Feature::Repository::YamlRepository do
 features:
     feature_a_active: true
     feature_b_active: true
-    feature_c_inactive: false
-    feature_d_inactive: false
+    feature_a_inactive: false
+    feature_b_inactive: false
 EOF
       fp.close
 
@@ -24,8 +24,8 @@ EOF
       File.delete(@filename)
     end
 
-    it 'should read active features from a config file' do
-      expect(@repo.active_features).to eq([:feature_a_active, :feature_b_active])
+    it_behaves_like "a repository" do
+      let(:repo) { @repo }
     end
 
     context 're-read config file' do

--- a/spec/feature/yaml_repository_spec.rb
+++ b/spec/feature/yaml_repository_spec.rb
@@ -24,7 +24,7 @@ EOF
       File.delete(@filename)
     end
 
-    it_behaves_like "a repository" do
+    it_behaves_like 'a repository' do
       let(:repo) { @repo }
     end
 

--- a/spec/shared_examples/dynamic_repository_examples.rb
+++ b/spec/shared_examples/dynamic_repository_examples.rb
@@ -9,12 +9,6 @@ shared_examples_for 'a dynamic repository' do
   end
 
   context 'with features added' do
-    it 'should be able to list all features' do
-      repo.create_feature(:feature_a, true)
-      repo.create_feature(:feature_b, false)
-      expect(repo.features.sort).to eq [:feature_a, :feature_b]
-    end
-
     it 'should be able to create an active feature' do
       repo.create_feature(:new_active_feature, true)
       expect(repo.get_feature(:new_active_feature)).to eq true

--- a/spec/shared_examples/dynamic_repository_examples.rb
+++ b/spec/shared_examples/dynamic_repository_examples.rb
@@ -26,8 +26,8 @@ shared_examples_for 'a dynamic repository' do
     end
 
     it 'should be able to add an active feature' do
-      repo.add_active_feature(:new_old_active_feature)
-      expect(repo.get_feature(:new_old_active_feature)).to eq true
+      repo.add_active_feature(:old_add_active_feature)
+      expect(repo.get_feature(:old_add_active_feature)).to eq true
     end
 
     it 'should be able to get an active features value' do

--- a/spec/shared_examples/dynamic_repository_examples.rb
+++ b/spec/shared_examples/dynamic_repository_examples.rb
@@ -1,56 +1,59 @@
 require 'spec_helper'
 
-shared_examples_for "a dynamic repository" do
+shared_examples_for 'a dynamic repository' do
   # define repo
-  context "after initialization" do
+  context 'after initialization' do
     it 'should have no active features' do
       expect(@repository.active_features).to eq([])
     end
   end
 
-  context "with features added" do
-    before do
+  context 'with features added' do
+    it 'should be able to list all features' do
       repo.create_feature(:active_feature, true)
       repo.create_feature(:inactive_feature, false)
-    end
-
-    it "should be able to list all features" do
       expect(repo.list_features.sort).to eq [:active_feature, :inactive_feature].sort
     end
 
-    it "should be able to create an active feature" do
+    it 'should be able to create an active feature' do
       repo.create_feature(:new_feature, true)
       expect(repo.get_feature(:new_feature)).to eq true
     end
 
-    it "should be able to create an inactive feature" do
+    it 'should be able to create an inactive feature' do
       repo.create_feature(:new_feature, false)
       expect(repo.get_feature(:new_feature)).to eq false
     end
 
-    it "should be able to add an active feature" do
+    it 'should be able to add an active feature' do
       repo.add_active_feature(:new_feature)
       expect(repo.get_feature(:new_feature)).to eq true
     end
 
-    it "should be able to add an inactive feature" do
+    it 'should be able to add an inactive feature' do
       repo.add_inactive_feature(:new_feature)
       expect(repo.get_feature(:new_feature)).to eq false
     end
 
-    it "should be able to get a feature's value" do
+    it 'should be able to get a features value' do
+      repo.create_feature(:active_feature, true)
+      repo.create_feature(:inactive_feature, false)
       expect(repo.get_feature(:active_feature)).to eq true
       expect(repo.get_feature(:inactive_feature)).to eq false
     end
 
-    it "should be able to set a feature's value" do
+    it 'should be able to set a features value' do
+      repo.create_feature(:active_feature, true)
+      repo.create_feature(:inactive_feature, false)
       repo.set_feature(:active_feature, false)
       expect(repo.get_feature(:active_feature)).to eq false
       repo.set_feature(:active_feature, true)
       expect(repo.get_feature(:active_feature)).to eq true
     end
 
-    it "should be able to delete a feature" do
+    it 'should be able to delete a feature' do
+      repo.create_feature(:active_feature, true)
+      repo.create_feature(:inactive_feature, false)
       expect(repo.list_features.include?(:active_feature)).to eq true
       expect(repo.remove_feature(:active_feature)).to eq true
     end

--- a/spec/shared_examples/dynamic_repository_examples.rb
+++ b/spec/shared_examples/dynamic_repository_examples.rb
@@ -4,7 +4,7 @@ shared_examples_for 'a dynamic repository' do
   # define repo
   context 'after initialization' do
     it 'should have no active features' do
-      expect(@repository.active_features).to eq([])
+      expect(repo.active_features).to eq([])
     end
   end
 

--- a/spec/shared_examples/dynamic_repository_examples.rb
+++ b/spec/shared_examples/dynamic_repository_examples.rb
@@ -2,63 +2,56 @@ require 'spec_helper'
 
 shared_examples_for 'a dynamic repository' do
   # define repo
-  context 'after initialization' do
-    it 'should have no active features' do
-      expect(repo.active_features).to eq([])
-    end
+
+  it 'should be able to create an active feature' do
+    repo.create_feature(:new_active_feature, true)
+    expect(repo.get_feature(:new_active_feature)).to eq true
   end
 
-  context 'with features added' do
-    it 'should be able to create an active feature' do
-      repo.create_feature(:new_active_feature, true)
-      expect(repo.get_feature(:new_active_feature)).to eq true
-    end
+  it 'should be able to create an inactive feature' do
+    repo.create_feature(:new_inactive_feature, false)
+    expect(repo.get_feature(:new_inactive_feature)).to eq false
+  end
 
-    it 'should be able to create an inactive feature' do
-      repo.create_feature(:new_inactive_feature, false)
-      expect(repo.get_feature(:new_inactive_feature)).to eq false
-    end
+  it 'should be able to add an active feature' do
+    repo.add_active_feature(:old_add_active_feature)
+    expect(repo.get_feature(:old_add_active_feature)).to eq true
+  end
 
-    it 'should be able to add an active feature' do
-      repo.add_active_feature(:old_add_active_feature)
-      expect(repo.get_feature(:old_add_active_feature)).to eq true
-    end
+  it 'should be able to get an active features value' do
+    repo.create_feature(:active_feature, true)
+    expect(repo.get_feature(:active_feature)).to eq true
+  end
 
-    it 'should be able to get an active features value' do
-      repo.create_feature(:active_feature, true)
-      expect(repo.get_feature(:active_feature)).to eq true
-    end
+  it 'should be able to get an inactive features value' do
+    repo.create_feature(:inactive_feature, false)
+    expect(repo.get_feature(:inactive_feature)).to eq false
+  end
 
-    it 'should be able to get an inactive features value' do
-      repo.create_feature(:inactive_feature, false)
-      expect(repo.get_feature(:inactive_feature)).to eq false
-    end
+  it 'should be able to set a features value' do
+    repo.create_feature(:feature_c, true)
+    repo.set_feature(:feature_c, false)
+    expect(repo.get_feature(:feature_c)).to eq false
+    repo.set_feature(:feature_c, true)
+    expect(repo.get_feature(:feature_c)).to eq true
+  end
 
-    it 'should be able to set a features value' do
-      repo.create_feature(:feature_c, true)
-      repo.set_feature(:feature_c, false)
-      expect(repo.get_feature(:feature_c)).to eq false
-      repo.set_feature(:feature_c, true)
-      expect(repo.get_feature(:feature_c)).to eq true
-    end
+  it 'should be able to delete a feature' do
+    repo.create_feature(:feature_d, true)
+    expect(repo.features.include?(:feature_d)).to eq true
+    expect(repo.remove_feature(:feature_d)).to eq true
+  end
 
-    it 'should be able to delete a feature' do
-      repo.create_feature(:feature_d, true)
-      expect(repo.features.include?(:feature_d)).to eq true
-      expect(repo.remove_feature(:feature_d)).to eq true
-    end
+  it 'should raise an exception when adding not a symbol as active feature' do
+    expect do
+      repo.add_active_feature 'feature_a'
+    end.to raise_error(ArgumentError, 'feature_a is not a symbol')
+  end
 
-    it 'should raise an exception when adding not a symbol as active feature' do
-      expect do
-        repo.add_active_feature 'feature_a'
-      end.to raise_error(ArgumentError, 'feature_a is not a symbol')
-    end
-
-    it 'should raise an exception when adding a active feature already added as active' do
+  it 'should raise an exception when adding a active feature already added as active' do
+    repo.add_active_feature :feature_f
+    expect do
       repo.add_active_feature :feature_f
-      expect do
-        repo.add_active_feature :feature_f
-      end.to raise_error(ArgumentError, 'feature :feature_f already added')
-    end
+    end.to raise_error(ArgumentError, 'feature :feature_f already added')
   end
 end

--- a/spec/shared_examples/dynamic_repository_examples.rb
+++ b/spec/shared_examples/dynamic_repository_examples.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+shared_examples_for "a dynamic repository" do
+  # define repo
+  context "after initialization" do
+    it 'should have no active features' do
+      expect(@repository.active_features).to eq([])
+    end
+  end
+
+  context "with features added" do
+    before do
+      repo.create_feature(:active_feature, true)
+      repo.create_feature(:inactive_feature, false)
+    end
+
+    it "should be able to list all features" do
+      expect(repo.list_features.sort).to eq [:active_feature, :inactive_feature].sort
+    end
+
+    it "should be able to create an active feature" do
+      repo.create_feature(:new_feature, true)
+      expect(repo.get_feature(:new_feature)).to eq true
+    end
+
+    it "should be able to create an inactive feature" do
+      repo.create_feature(:new_feature, false)
+      expect(repo.get_feature(:new_feature)).to eq false
+    end
+
+    it "should be able to add an active feature" do
+      repo.add_active_feature(:new_feature)
+      expect(repo.get_feature(:new_feature)).to eq true
+    end
+
+    it "should be able to add an inactive feature" do
+      repo.add_inactive_feature(:new_feature)
+      expect(repo.get_feature(:new_feature)).to eq false
+    end
+
+    it "should be able to get a feature's value" do
+      expect(repo.get_feature(:active_feature)).to eq true
+      expect(repo.get_feature(:inactive_feature)).to eq false
+    end
+
+    it "should be able to set a feature's value" do
+      repo.set_feature(:active_feature, false)
+      expect(repo.get_feature(:active_feature)).to eq false
+      repo.set_feature(:active_feature, true)
+      expect(repo.get_feature(:active_feature)).to eq true
+    end
+
+    it "should be able to delete a feature" do
+      expect(repo.list_features.include?(:active_feature)).to eq true
+      expect(repo.remove_feature(:active_feature)).to eq true
+    end
+
+    it 'should raise an exception when adding not a symbol as active feature' do
+      expect do
+        repo.add_active_feature 'feature_a'
+      end.to raise_error(ArgumentError, 'feature_a is not a symbol')
+    end
+
+    it 'should raise an exception when adding a active feature already added as active' do
+      repo.add_active_feature :feature_a
+      expect do
+        repo.add_active_feature :feature_a
+      end.to raise_error(ArgumentError, 'feature :feature_a already added')
+    end
+  end
+end

--- a/spec/shared_examples/dynamic_repository_examples.rb
+++ b/spec/shared_examples/dynamic_repository_examples.rb
@@ -10,52 +10,48 @@ shared_examples_for 'a dynamic repository' do
 
   context 'with features added' do
     it 'should be able to list all features' do
-      repo.create_feature(:active_feature, true)
-      repo.create_feature(:inactive_feature, false)
-      expect(repo.list_features.sort).to eq [:active_feature, :inactive_feature].sort
+      repo.create_feature(:feature_a, true)
+      repo.create_feature(:feature_b, false)
+      expect(repo.features.sort).to eq [:feature_a, :feature_b]
     end
 
     it 'should be able to create an active feature' do
-      repo.create_feature(:new_feature, true)
-      expect(repo.get_feature(:new_feature)).to eq true
+      repo.create_feature(:new_active_feature, true)
+      expect(repo.get_feature(:new_active_feature)).to eq true
     end
 
     it 'should be able to create an inactive feature' do
-      repo.create_feature(:new_feature, false)
-      expect(repo.get_feature(:new_feature)).to eq false
+      repo.create_feature(:new_inactive_feature, false)
+      expect(repo.get_feature(:new_inactive_feature)).to eq false
     end
 
     it 'should be able to add an active feature' do
-      repo.add_active_feature(:new_feature)
-      expect(repo.get_feature(:new_feature)).to eq true
+      repo.add_active_feature(:new_old_active_feature)
+      expect(repo.get_feature(:new_old_active_feature)).to eq true
     end
 
-    it 'should be able to add an inactive feature' do
-      repo.add_inactive_feature(:new_feature)
-      expect(repo.get_feature(:new_feature)).to eq false
-    end
-
-    it 'should be able to get a features value' do
+    it 'should be able to get an active features value' do
       repo.create_feature(:active_feature, true)
-      repo.create_feature(:inactive_feature, false)
       expect(repo.get_feature(:active_feature)).to eq true
+    end
+
+    it 'should be able to get an inactive features value' do
+      repo.create_feature(:inactive_feature, false)
       expect(repo.get_feature(:inactive_feature)).to eq false
     end
 
     it 'should be able to set a features value' do
-      repo.create_feature(:active_feature, true)
-      repo.create_feature(:inactive_feature, false)
-      repo.set_feature(:active_feature, false)
-      expect(repo.get_feature(:active_feature)).to eq false
-      repo.set_feature(:active_feature, true)
-      expect(repo.get_feature(:active_feature)).to eq true
+      repo.create_feature(:feature_c, true)
+      repo.set_feature(:feature_c, false)
+      expect(repo.get_feature(:feature_c)).to eq false
+      repo.set_feature(:feature_c, true)
+      expect(repo.get_feature(:feature_c)).to eq true
     end
 
     it 'should be able to delete a feature' do
-      repo.create_feature(:active_feature, true)
-      repo.create_feature(:inactive_feature, false)
-      expect(repo.list_features.include?(:active_feature)).to eq true
-      expect(repo.remove_feature(:active_feature)).to eq true
+      repo.create_feature(:feature_d, true)
+      expect(repo.features.include?(:feature_d)).to eq true
+      expect(repo.remove_feature(:feature_d)).to eq true
     end
 
     it 'should raise an exception when adding not a symbol as active feature' do
@@ -65,10 +61,10 @@ shared_examples_for 'a dynamic repository' do
     end
 
     it 'should raise an exception when adding a active feature already added as active' do
-      repo.add_active_feature :feature_a
+      repo.add_active_feature :feature_f
       expect do
-        repo.add_active_feature :feature_a
-      end.to raise_error(ArgumentError, 'feature :feature_a already added')
+        repo.add_active_feature :feature_f
+      end.to raise_error(ArgumentError, 'feature :feature_f already added')
     end
   end
 end

--- a/spec/shared_examples/repository_examples.rb
+++ b/spec/shared_examples/repository_examples.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
-shared_examples_for "a repository" do
+shared_examples_for 'a repository' do
   # define repo with the following active features: :feature_a_active, :feature_b_active
   #            and the following inactive features: :feature_a_inactive, :feature_b_inactive
-
 
   it '#active_features should only show active features' do
     expect(repo.active_features).to eq([:feature_a_active, :feature_b_active])
@@ -20,7 +19,13 @@ shared_examples_for "a repository" do
     expect(repo.get_feature(:feature_b_active)).to eq true
   end
 
-  it "#list_features should list all features" do
-    expect(repo.list_features.sort).to eq [:feature_a_active, :feature_b_active, :feature_a_inactive, :feature_b_inactive].sort
+  it '#list_features should list all features' do
+    feature_list = [
+      :feature_a_active,
+      :feature_b_active,
+      :feature_a_inactive,
+      :feature_b_inactive
+    ]
+    expect(repo.list_features.sort).to eq feature_list.sort
   end
 end

--- a/spec/shared_examples/repository_examples.rb
+++ b/spec/shared_examples/repository_examples.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+shared_examples_for "a repository" do
+  # define repo with the following active features: :feature_a_active, :feature_b_active
+  #            and the following inactive features: :feature_a_inactive, :feature_b_inactive
+
+
+  it '#active_features should only show active features' do
+    expect(repo.active_features).to eq([:feature_a_active, :feature_b_active])
+  end
+
+  it '#inactive_features should only show active features' do
+    expect(repo.inactive_features).to eq([:feature_a_inactive, :feature_b_inactive])
+  end
+
+  it '#get_feature should only show active features' do
+    expect(repo.get_feature(:feature_a_inactive)).to eq false
+    expect(repo.get_feature(:feature_a_active)).to eq true
+    expect(repo.get_feature(:feature_b_inactive)).to eq false
+    expect(repo.get_feature(:feature_b_active)).to eq true
+  end
+
+  it "#list_features should list all features" do
+    expect(repo.list_features.sort).to eq [:feature_a_active, :feature_b_active, :feature_a_inactive, :feature_b_inactive].sort
+  end
+end

--- a/spec/shared_examples/repository_examples.rb
+++ b/spec/shared_examples/repository_examples.rb
@@ -19,13 +19,13 @@ shared_examples_for 'a repository' do
     expect(repo.get_feature(:feature_b_active)).to eq true
   end
 
-  it '#list_features should list all features' do
+  it '#features should list all features' do
     feature_list = [
       :feature_a_active,
       :feature_b_active,
       :feature_a_inactive,
       :feature_b_inactive
     ]
-    expect(repo.list_features.sort).to eq feature_list.sort
+    expect(repo.features.sort).to eq feature_list.sort
   end
 end

--- a/spec/shared_examples/repository_examples.rb
+++ b/spec/shared_examples/repository_examples.rb
@@ -4,12 +4,22 @@ shared_examples_for 'a repository' do
   # define repo with the following active features: :feature_a_active, :feature_b_active
   #            and the following inactive features: :feature_a_inactive, :feature_b_inactive
 
+  it 'should be able to return a hash of all features and their current state' do
+    features = {
+      feature_a_active: true,
+      feature_a_inactive: false,
+      feature_b_active: true,
+      feature_b_inactive: false
+    }
+    expect(repo.features).to eq features
+  end
+
   it '#active_features should only show active features' do
-    expect(repo.active_features).to eq([:feature_a_active, :feature_b_active])
+    expect(repo.active_features.sort).to eq([:feature_a_active, :feature_b_active].sort)
   end
 
   it '#inactive_features should only show active features' do
-    expect(repo.inactive_features).to eq([:feature_a_inactive, :feature_b_inactive])
+    expect(repo.inactive_features.sort).to eq([:feature_a_inactive, :feature_b_inactive].sort)
   end
 
   it '#get_feature should only show active features' do
@@ -17,15 +27,5 @@ shared_examples_for 'a repository' do
     expect(repo.get_feature(:feature_a_active)).to eq true
     expect(repo.get_feature(:feature_b_inactive)).to eq false
     expect(repo.get_feature(:feature_b_active)).to eq true
-  end
-
-  it '#features should list all features' do
-    feature_list = [
-      :feature_a_active,
-      :feature_b_active,
-      :feature_a_inactive,
-      :feature_b_inactive
-    ]
-    expect(repo.features.sort).to eq feature_list.sort
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,3 +11,5 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 SPEC_ROOT = Pathname(__FILE__).dirname.expand_path
 
 require SPEC_ROOT.parent + 'lib/feature'
+require SPEC_ROOT + 'shared_examples/dynamic_repository_examples'
+require SPEC_ROOT + 'shared_examples/repository_examples'


### PR DESCRIPTION
Standardized the api for repositories, so that you can use the same methods to read features across all repositories, and add/update/delete features across all dynamic repositories

All repositories now respond to:
* repo#active_features => [Array<Symbol>] all active features
* repo#inactive_features => [Array<Symbol>] all inactive features
* repo#list_features => [Array<Symbol>] all features
* repo#get_feature(<Symbol> feature_name) => true || false depending on if feature is active

All dynamic repositories now respond to:
* repo#add_active_feature(<Symbol> feature_name) => true || false (successfully added)
* repo#add_inactive_feature(<Symbol> feature_name) => true || false (successfully added)
* repo#remove_feature(<Symbol> feature_name) => true || false (successfully removed)
* repo#create_feature(<Symbol> feature_name, <Boolean> active) => true || false (successfully added)
* repo#set_feature(<Symbol> feature_name, <Boolean> active) => true || false (successfully updated)

RedisRepository:
* Added the ability to set custom redis client

ActiveRecordRepository:
* Fixed the call to 'exists?' to make the call against 'name' instead of the default 'id'
