### PR TITLE
Change the default behavior of auto_refresh

### DIFF
--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -33,14 +33,14 @@ module Feature
   # @param [Object] repository the repository to get the features from
   # @param [Boolean] auto_refresh optional (default: false) - refresh feature toggles on every check if set true
   #
-  def self.set_repository(repository, auto_refresh = false)
+  def self.set_repository(repository, auto_refresh = nil)
     unless repository.respond_to?(:active_features)
       fail ArgumentError, 'given repository does not respond to active_features'
     end
 
-    @auto_refresh = auto_refresh
     @perform_initial_refresh = true
     @repository = repository
+    @auto_refresh = auto_refresh.nil? ? @repository.default_auto_refresh : auto_refresh
   end
 
   # Refreshes list of active features from repository.

--- a/lib/feature/repository/active_record_repository.rb
+++ b/lib/feature/repository/active_record_repository.rb
@@ -16,6 +16,11 @@ module Feature
         @model = model
       end
 
+      # auto_refresh is enabled by default
+      def default_auto_refresh
+        true
+      end
+
       # Returns list of active features
       #
       # @return [Array<Symbol>] list of active features

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -18,6 +18,11 @@ module Feature
         @redis_key = redis_key
       end
 
+      # auto_refresh is enabled by default
+      def default_auto_refresh
+        true
+      end
+
       # Returns list of active features
       #
       # @return [Array<Symbol>] list of active features

--- a/lib/feature/repository/simple_repository.rb
+++ b/lib/feature/repository/simple_repository.rb
@@ -16,6 +16,11 @@ module Feature
         @active_features = []
       end
 
+      # auto_refresh is enabled by default
+      def default_auto_refresh
+        true
+      end
+
       # Returns list of active features
       #
       # @return [Array<Symbol>] list of active features

--- a/lib/feature/repository/yaml_repository.rb
+++ b/lib/feature/repository/yaml_repository.rb
@@ -36,6 +36,11 @@ module Feature
         @environment = environment
       end
 
+      # auto_refresh is enabled by default
+      def default_auto_refresh
+        false
+      end
+
       # Returns list of active features
       #
       # @return [Array<Symbol>] list of active features

--- a/lib/feature/repository/yaml_repository.rb
+++ b/lib/feature/repository/yaml_repository.rb
@@ -36,7 +36,7 @@ module Feature
         @environment = environment
       end
 
-      # auto_refresh is enabled by default
+      # auto_refresh is disabled by default
       def default_auto_refresh
         false
       end

--- a/spec/feature/active_record_repository_spec.rb
+++ b/spec/feature/active_record_repository_spec.rb
@@ -15,6 +15,10 @@ describe Feature::Repository::ActiveRecordRepository do
     expect(@repository.active_features).to eq([])
   end
 
+  it 'should have a default auto_refresh value of false' do
+    expect(@repository.default_auto_refresh).to eq true
+  end
+
   it 'should have active features' do
     allow(@features).to receive(:where).with(active: true) { [double(name: 'active')] }
 

--- a/spec/feature/feature_spec.rb
+++ b/spec/feature/feature_spec.rb
@@ -36,7 +36,7 @@ describe Feature do
 
     context 'with auto_refresh set to false' do
       before(:each) do
-        Feature.set_repository @repository
+        Feature.set_repository @repository, false
       end
       it 'should raise an exception when add repository with wrong class' do
         expect do

--- a/spec/feature/redis_repository_spec.rb
+++ b/spec/feature/redis_repository_spec.rb
@@ -16,6 +16,10 @@ describe Feature::Repository::RedisRepository do
     expect(@repository.active_features).to eq([:feature_a])
   end
 
+  it 'should have a default auto_refresh value of false' do
+    expect(@repository.default_auto_refresh).to eq true
+  end
+
   it 'should only show active feature' do
     Redis.current.hset('application_features', 'inactive_a', false)
     Redis.current.hset('application_features', 'inactive_b', false)

--- a/spec/feature/simple_repository_spec.rb
+++ b/spec/feature/simple_repository_spec.rb
@@ -22,6 +22,10 @@ describe Feature::Repository::SimpleRepository do
     expect(list).to eq([])
   end
 
+  it 'should have a default auto_refresh value of false' do
+    expect(@repository.default_auto_refresh).to eq true
+  end
+
   it 'should raise an exception when adding not a symbol as active feature' do
     expect do
       @repository.add_active_feature 'feature_a'

--- a/spec/feature/yaml_repository_spec.rb
+++ b/spec/feature/yaml_repository_spec.rb
@@ -28,6 +28,10 @@ EOF
       expect(@repo.active_features).to eq([:feature_a_active, :feature_b_active])
     end
 
+    it 'should have a default auto_refresh value of false' do
+      expect(@repo.default_auto_refresh).to eq false
+    end
+
     context 're-read config file' do
       before(:each) do
         fp = File.new(@filename, 'w')


### PR DESCRIPTION
The logical default auto_refresh value changes depending on which repository type you are using. So, I believe it makes sense to set the default auto_refresh value at the repository level. The value of being able to toggle features during runtime is essentially lost for the dynamic repository classes with the current default value.