### PR TITLE
Add Timeout to refresh Repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :test do
   gem 'rspec-mocks'
   gem 'coveralls', require: false
   gem 'rubocop', require: false
+  gem 'timecop'
   gem 'fakeredis'
   if RUBY_VERSION >= '2.1'
     gem 'mutant'

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ end
 task :mutant do
   require 'mutant'
   result = Mutant::CLI.run(%w(--include lib --require feature --use rspec Feature*))
-  fail unless result == Mutant::CLI::EXIT_SUCCESS
+  raise unless result == Mutant::CLI::EXIT_SUCCESS
 end
 
 task default: [:spec, :rubocop]

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -51,14 +51,14 @@ module Feature
   #
   def self.refresh!
     @active_features = @repository.active_features
-    @last_refresh = Time.now if !!@timeout
+    @last_refresh = Time.now if @timeout
     @perform_initial_refresh = false
   end
 
   # returns true if refresh is due because of timeout set
   #
   def self.timeout_refresh?
-    !!@timeout && (Time.now - @last_refresh) > @timeout
+    @timeout && (Time.now - @last_refresh) > @timeout
   end
 
   ##

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -36,7 +36,7 @@ module Feature
   #
   def self.set_repository(repository, auto_refresh = false, timeout = nil)
     unless repository.respond_to?(:active_features)
-      fail ArgumentError, 'given repository does not respond to active_features'
+      raise ArgumentError, 'given repository does not respond to active_features'
     end
 
     @auto_refresh = auto_refresh
@@ -68,7 +68,7 @@ module Feature
   # @return [Boolean]
   #
   def self.active?(feature)
-    fail 'missing Repository for obtaining feature lists' unless @repository
+    raise 'missing Repository for obtaining feature lists' unless @repository
 
     refresh! if @auto_refresh || @perform_initial_refresh || timeout_refresh?
 
@@ -89,7 +89,7 @@ module Feature
   # @param [Symbol] feature
   #
   def self.with(feature)
-    fail ArgumentError, "no block given to #{__method__}" unless block_given?
+    raise ArgumentError, "no block given to #{__method__}" unless block_given?
 
     yield if active?(feature)
   end
@@ -99,7 +99,7 @@ module Feature
   # @param [Symbol] feature
   #
   def self.without(feature)
-    fail ArgumentError, "no block given to #{__method__}" unless block_given?
+    raise ArgumentError, "no block given to #{__method__}" unless block_given?
 
     yield if inactive?(feature)
   end

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -70,7 +70,7 @@ module Feature
   def self.active?(feature)
     fail 'missing Repository for obtaining feature lists' unless @repository
 
-    refresh! if @auto_refresh || @perform_initial_refresh || require_refresh?
+    refresh! if @auto_refresh || @perform_initial_refresh || timeout_refresh?
 
     @active_features.include?(feature)
   end

--- a/lib/feature/repository/active_record_repository.rb
+++ b/lib/feature/repository/active_record_repository.rb
@@ -39,7 +39,7 @@ module Feature
       # @param [Sybmol] feature the feature to be checked
       #
       def check_feature_is_not_symbol(feature)
-        fail ArgumentError, "#{feature} is not a symbol" unless feature.instance_of?(Symbol)
+        raise ArgumentError, "#{feature} is not a symbol" unless feature.instance_of?(Symbol)
       end
       private :check_feature_is_not_symbol
 
@@ -49,7 +49,7 @@ module Feature
       # @param [Symbol] feature the feature to be checked
       #
       def check_feature_already_in_list(feature)
-        fail ArgumentError, "feature :#{feature} already added" if @model.exists?(feature.to_s)
+        raise ArgumentError, "feature :#{feature} already added" if @model.exists?(feature.to_s)
       end
       private :check_feature_already_in_list
     end

--- a/lib/feature/repository/active_record_repository.rb
+++ b/lib/feature/repository/active_record_repository.rb
@@ -29,9 +29,7 @@ module Feature
       # @param [Symbol] feature the feature to be added
       #
       def add_inactive_feature(feature)
-        check_feature_is_not_symbol(feature)
-        check_feature_already_in_list(feature)
-        @model.create!(name: feature.to_s, active: false)
+        add_feature(feature, false)
       end
 
       # Add an active feature to repository
@@ -39,9 +37,18 @@ module Feature
       # @param [Symbol] feature the feature to be added
       #
       def add_active_feature(feature)
+        add_feature(feature, true)
+      end
+
+      # Add a feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      # @param [Boolean] state the active state (true=active, false=inactive)
+      #
+      def add_feature(feature, state)
         check_feature_is_not_symbol(feature)
         check_feature_already_in_list(feature)
-        @model.create!(name: feature.to_s, active: true)
+        @model.create!(name: feature.to_s, active: state)
       end
 
       # Checks if the given feature is a not symbol and raises an exception if so

--- a/lib/feature/repository/active_record_repository.rb
+++ b/lib/feature/repository/active_record_repository.rb
@@ -24,6 +24,16 @@ module Feature
         @model.where(active: true).map { |f| f.name.to_sym }
       end
 
+      # Add an inactive feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def add_inactive_feature(feature)
+        check_feature_is_not_symbol(feature)
+        check_feature_already_in_list(feature)
+        @model.create!(name: feature.to_s, active: false)
+      end
+
       # Add an active feature to repository
       #
       # @param [Symbol] feature the feature to be added

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -26,14 +26,23 @@ module Feature
         Redis.current.hgetall(@redis_key).select { |_k, v| v.to_s == 'true' }.map { |k, _v| k.to_sym }
       end
 
+      # Add a feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      # @param [Boolean] feature the state of the feature active=true
+      #
+      def add_feature(feature, state)
+        check_feature_is_not_symbol(feature)
+        check_feature_already_in_list(feature)
+        Redis.current.hset(@redis_key, feature, state)
+      end
+
       # Add an inactive feature to repository
       #
       # @param [Symbol] feature the feature to be added
       #
       def add_inactive_feature(feature)
-        check_feature_is_not_symbol(feature)
-        check_feature_already_in_list(feature)
-        Redis.current.hset(@redis_key, feature, false)
+        add_feature(feature, false)
       end
 
       # Add an active feature to repository
@@ -41,9 +50,7 @@ module Feature
       # @param [Symbol] feature the feature to be added
       #
       def add_active_feature(feature)
-        check_feature_is_not_symbol(feature)
-        check_feature_already_in_list(feature)
-        Redis.current.hset(@redis_key, feature, true)
+        add_feature(feature, true)
       end
 
       # Checks that given feature is a symbol, raises exception otherwise

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -41,7 +41,7 @@ module Feature
       # @param [Sybmol] feature the feature to be checked
       #
       def check_feature_is_not_symbol(feature)
-        fail ArgumentError, "#{feature} is not a symbol" unless feature.instance_of?(Symbol)
+        raise ArgumentError, "#{feature} is not a symbol" unless feature.instance_of?(Symbol)
       end
       private :check_feature_is_not_symbol
 
@@ -51,7 +51,7 @@ module Feature
       # @param [Symbol] feature the feature to be checked
       #
       def check_feature_already_in_list(feature)
-        fail ArgumentError, "feature :#{feature} already added" if Redis.current.hexists(@redis_key, feature)
+        raise ArgumentError, "feature :#{feature} already added" if Redis.current.hexists(@redis_key, feature)
       end
       private :check_feature_already_in_list
     end

--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -26,6 +26,16 @@ module Feature
         Redis.current.hgetall(@redis_key).select { |_k, v| v.to_s == 'true' }.map { |k, _v| k.to_sym }
       end
 
+      # Add an inactive feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def add_inactive_feature(feature)
+        check_feature_is_not_symbol(feature)
+        check_feature_already_in_list(feature)
+        Redis.current.hset(@redis_key, feature, false)
+      end
+
       # Add an active feature to repository
       #
       # @param [Symbol] feature the feature to be added

--- a/lib/feature/repository/simple_repository.rb
+++ b/lib/feature/repository/simple_repository.rb
@@ -39,7 +39,7 @@ module Feature
       # @param [Sybmol] feature the feature to be checked
       #
       def check_feature_is_not_symbol(feature)
-        fail ArgumentError, "#{feature} is not a symbol" unless feature.instance_of?(Symbol)
+        raise ArgumentError, "#{feature} is not a symbol" unless feature.instance_of?(Symbol)
       end
       private :check_feature_is_not_symbol
 
@@ -49,7 +49,7 @@ module Feature
       # @param [Symbol] feature the feature to be checked
       #
       def check_feature_already_in_list(feature)
-        fail ArgumentError, "feature :#{feature} already added" if @active_features.include?(feature)
+        raise ArgumentError, "feature :#{feature} already added" if @active_features.include?(feature)
       end
       private :check_feature_already_in_list
     end

--- a/lib/feature/repository/simple_repository.rb
+++ b/lib/feature/repository/simple_repository.rb
@@ -24,6 +24,14 @@ module Feature
         @active_features.dup
       end
 
+      # Add an inactive feature to repository
+      #
+      # @param [Symbol] feature the feature to be added
+      #
+      def add_inactive_feature(feature)
+        # do nothing. keep it here for consistency of the interface
+      end
+
       # Add an active feature to repository
       #
       # @param [Symbol] feature the feature to be added

--- a/lib/feature/repository/yaml_repository.rb
+++ b/lib/feature/repository/yaml_repository.rb
@@ -66,7 +66,7 @@ module Feature
         data = data[selector] unless selector.empty?
 
         if !data.is_a?(Hash) || !data.key?('features')
-          fail ArgumentError, 'yaml config does not contain proper config'
+          raise ArgumentError, 'yaml config does not contain proper config'
         end
 
         return [] unless data['features']
@@ -84,7 +84,7 @@ module Feature
       def check_valid_feature_data(features)
         features.values.each do |value|
           unless [true, false].include?(value)
-            fail ArgumentError, "#{value} is not allowed value in config, use true/false"
+            raise ArgumentError, "#{value} is not allowed value in config, use true/false"
           end
         end
       end

--- a/spec/feature/active_record_repository_spec.rb
+++ b/spec/feature/active_record_repository_spec.rb
@@ -28,6 +28,13 @@ describe Feature::Repository::ActiveRecordRepository do
     @repository.add_active_feature :feature_a
   end
 
+  it 'should add an inactive feature' do
+    expect(@features).to receive(:exists?).with('feature_a').and_return(false)
+    expect(@features).to receive(:create!).with(name: 'feature_a', active: false)
+
+    @repository.add_inactive_feature :feature_a
+  end
+
   it 'should raise an exception when adding not a symbol as active feature' do
     expect do
       @repository.add_active_feature 'feature_a'

--- a/spec/feature/feature_spec.rb
+++ b/spec/feature/feature_spec.rb
@@ -75,6 +75,27 @@ describe Feature do
         Feature.active?(:feature_a)
       end
     end
+
+    context 'with timeout set to 30 seconds' do
+      before(:each) do
+        Timecop.freeze(Time.now)
+        Feature.set_repository @repository, false, 30
+        @repository.add_active_feature(:feature_a)
+        Feature.active?(:feature_a)
+      end
+
+      it 'should not update after 10 seconds' do
+        Timecop.freeze(Time.now + 10)
+        expect(@repository).not_to receive(:active_features)
+        Feature.active?(:feature_a)
+      end
+
+      it 'should update after 40 seconds' do
+        Timecop.freeze(Time.now + 40)
+        expect(@repository).to receive(:active_features).and_return(@repository.active_features)
+        Feature.active?(:feature_a)
+      end
+    end
   end
 
   context 'refresh features' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'timecop'
 require 'coveralls'
 require 'fakeredis/rspec'
 


### PR DESCRIPTION
In order to update from repo with putting to much pressure on the storage, a timeout can be set on repo assignment. This timeout in seconds allows update of flags in distributed deployments.