### PR TITLE
Introduce Feature.active_list for exposing all active features

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ Metrics/LineLength:
 # Offense count: 1
 Metrics/AbcSize:
   Max: 17
+
+Style/SignalException:
+  EnforcedStyle: only_fail

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -107,4 +107,11 @@ module Feature
       l2.instance_of?(Proc) ? l2.call : l2
     end
   end
+
+  # Return list of active feature flags.
+  #
+  # @return [Array] list of symbols
+  def self.active_list
+    @active_features
+  end
 end

--- a/spec/feature/feature_spec.rb
+++ b/spec/feature/feature_spec.rb
@@ -190,5 +190,11 @@ describe Feature do
         end
       end
     end
+
+    describe '.active_list' do
+      it 'should return an array of active feature flags' do
+        expect(Feature.active_list).to eq([:feature_active])
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a small modification which increases the API of the Feature module. In short, I encountered a situation in which it would be beneficial to capture _all_ the feature flags currently enabled. The only interface to that is through the repository, which has long been forgotten about.

Happy to change the name of the method, it's just a pass through to the existing `@active_features` variable.

Also, snuck in a change to make rubocop happy and rake green.

I'm curious why Feature is a stateful module rather than a class or something... it made it a bit more challenging to write some meaningful tests for, because it was so hard to blow away the existing state. Anyway, there might not be an answer for this given that it seems pretty quiet around here lately. But this is my go-to feature library, purely for its simplicity and versatility.

Cheers, and let me know your thoughts.