### PR TITLE
Add ability to retrieve a list of all active features

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ With this approach Feature is highly configurable and not bound to a specific ki
 
 * Use Feature in your production code
 
+        Feature.active_features # => list of active feature symbols
+
         Feature.active?(:feature_name) # => true/false
 
         Feature.inactive?(:feature_name) # => true/false
@@ -50,7 +52,7 @@ With this approach Feature is highly configurable and not bound to a specific ki
         end
 
         # this returns value_true if :feature_name is active, otherwise value_false
-        Feature.switch(:feature_name, value_true, value_false) 
+        Feature.switch(:feature_name, value_true, value_false)
 
         # switch may also take Procs that will be evaluated and it's result returned.
         Feature.switch(:feature_name, -> { code... }, -> { code... })
@@ -72,12 +74,12 @@ With this approach Feature is highly configurable and not bound to a specific ki
 
     * By default, Feature will lazy-load the active features from the
       underlying repository the first time you try to check whether a
-      feature is set or not. 
+      feature is set or not.
 
     * Subsequent calls to Feature will access the cached in-memory
-      representation of the list of features. So changes to toggles in the 
+      representation of the list of features. So changes to toggles in the
       underlying repository would not be reflected in the application
-      until you restart the application or manally call 
+      until you restart the application or manally call
 
             Feature.refresh!
 
@@ -85,7 +87,7 @@ With this approach Feature is highly configurable and not bound to a specific ki
       set_repository, to force Feature to auto-refresh the feature list
       on every feature-toggle check you make.
 
-            Feature.set_repository(your_repository, true) 
+            Feature.set_repository(your_repository, true)
 
 ## How to setup different backends
 

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -51,6 +51,15 @@ module Feature
     @perform_initial_refresh = false
   end
 
+  # Returns the list of all active features
+  def self.active_features
+    fail 'missing Repository for obtaining feature lists' unless @repository
+
+    refresh! if @auto_refresh || @perform_initial_refresh
+
+    @active_features
+  end
+
   ##
   # Requests if feature is active
   #

--- a/spec/feature/feature_spec.rb
+++ b/spec/feature/feature_spec.rb
@@ -8,6 +8,12 @@ describe Feature do
       end.to raise_error('missing Repository for obtaining feature lists')
     end
 
+    it 'should raise an exception when calling active_features' do
+      expect do
+        Feature.active_features
+      end.to raise_error('missing Repository for obtaining feature lists')
+    end
+
     it 'should raise an exception when calling inactive?' do
       expect do
         Feature.inactive?(:feature_a)
@@ -95,6 +101,12 @@ describe Feature do
       repository = Feature::Repository::SimpleRepository.new
       repository.add_active_feature :feature_active
       Feature.set_repository repository
+    end
+
+    it 'should affirm active features' do
+      expect(Feature.active_features.count).to eq(1)
+      expect(Feature.active_features.include? :feature_active).to be_truthy
+      expect(Feature.active_features.include? :feature_inactive).to be_falsey
     end
 
     it 'should affirm active feature is active' do


### PR DESCRIPTION
Satisfy the request in issue #36 and pull request #35 (oops, should have looked a little closer first, thanks to @pmeskers).   Only real difference is the name of the function is the same as the instance variable (`Feature.active_features`)

The net is that this provides the ability to retrieve a list of all of the active feature symbols.  Very helpful to display on a debug page.