### PR TITLE
ActiveRecordRepo Bug Fix

### DIFF
--- a/lib/feature/repository/active_record_repository.rb
+++ b/lib/feature/repository/active_record_repository.rb
@@ -49,7 +49,7 @@ module Feature
       # @param [Symbol] feature the feature to be checked
       #
       def check_feature_already_in_list(feature)
-        raise ArgumentError, "feature :#{feature} already added" if @model.exists?(feature.to_s)
+        raise ArgumentError, "feature :#{feature} already added" if @model.exists?(name: feature.to_s)
       end
       private :check_feature_already_in_list
     end

--- a/spec/feature/active_record_repository_spec.rb
+++ b/spec/feature/active_record_repository_spec.rb
@@ -22,7 +22,7 @@ describe Feature::Repository::ActiveRecordRepository do
   end
 
   it 'should add an active feature' do
-    expect(@features).to receive(:exists?).with('feature_a').and_return(false)
+    expect(@features).to receive(:exists?).with(name: 'feature_a').and_return(false)
     expect(@features).to receive(:create!).with(name: 'feature_a', active: true)
 
     @repository.add_active_feature :feature_a


### PR DESCRIPTION
Currently, the ActiveRecord repo assumes that the primary key of the feature model is set to `name`.

Considering the default primary key for a model is `id`, I have removed the restriction on setting it to name. Now it just requires a `name` column, but does not care whether or not `name` is the primary key.