### PR TITLE
allow for the setting of a custom redis client

### DIFF
--- a/lib/feature/repository/redis_repository.rb
+++ b/lib/feature/repository/redis_repository.rb
@@ -10,12 +10,15 @@ module Feature
     # the Redis hash that will store all of your feature toggles.
     #
     class RedisRepository
+      attr_writer :redis
+      
       # Constructor
       #
       # @param redis_key the key of the redis hash where all the toggles will be stored
       #
-      def initialize(redis_key)
+      def initialize(redis_key, client=nil)
         @redis_key = redis_key
+        @redis = client unless client.nil?
       end
 
       # Returns list of active features
@@ -23,7 +26,7 @@ module Feature
       # @return [Array<Symbol>] list of active features
       #
       def active_features
-        Redis.current.hgetall(@redis_key).select { |_k, v| v.to_s == 'true' }.map { |k, _v| k.to_sym }
+        redis.hgetall(@redis_key).select { |_k, v| v.to_s == 'true' }.map { |k, _v| k.to_sym }
       end
 
       # Add an active feature to repository
@@ -33,7 +36,7 @@ module Feature
       def add_active_feature(feature)
         check_feature_is_not_symbol(feature)
         check_feature_already_in_list(feature)
-        Redis.current.hset(@redis_key, feature, true)
+        redis.hset(@redis_key, feature, true)
       end
 
       # Checks that given feature is a symbol, raises exception otherwise
@@ -51,9 +54,18 @@ module Feature
       # @param [Symbol] feature the feature to be checked
       #
       def check_feature_already_in_list(feature)
-        raise ArgumentError, "feature :#{feature} already added" if Redis.current.hexists(@redis_key, feature)
+        raise ArgumentError, "feature :#{feature} already added" if redis.hexists(@redis_key, feature)
       end
       private :check_feature_already_in_list
+
+      # Returns the currently specified redis client
+      #
+      # @return [Redis] Currently set redis client
+      #
+      def redis
+        @redis ||= Redis.current
+      end
+      private :redis
     end
   end
 end

--- a/spec/feature/redis_repository_spec.rb
+++ b/spec/feature/redis_repository_spec.rb
@@ -37,4 +37,10 @@ describe Feature::Repository::RedisRepository do
       @repository.add_active_feature :feature_a
     end.to raise_error(ArgumentError, 'feature :feature_a already added')
   end
+
+  let(:specified_redis) { double }
+  let(:repo) { RedisRepository.new('application_features', specified_redis) }
+  it 'should allow you to specify the redis instance to use' do
+    expect(repo.send(:redis)).to eq specified_redis
+  end
 end


### PR DESCRIPTION
In some cases, `Redis.current` is not sufficient. One case in particular (which is used by resque) is: https://github.com/resque/redis-namespace

That gem allows for the setting of namespaces for easier key management, with the present setup however, you cannot point the gem to use an appropriately name-spaced client.

In addition, there are other cases where `Redis.current` may not be sufficient. 
* a single application may need to communicate with multiple redis servers
* other decorated forms of redis client
* drop in replacements for redis