### PR TITLE
Autoload repositories and don't require them explicitly

### DIFF
--- a/lib/feature/repository.rb
+++ b/lib/feature/repository.rb
@@ -1,9 +1,9 @@
 module Feature
   # Module for holding feature repositories
   module Repository
-    require 'feature/repository/simple_repository'
-    require 'feature/repository/yaml_repository'
-    require 'feature/repository/active_record_repository'
-    require 'feature/repository/redis_repository'
+    autoload :SimpleRepository, 'feature/repository/simple_repository'
+    autoload :YamlRepository, 'feature/repository/yaml_repository'
+    autoload :ActiveRecordRepository, 'feature/repository/active_record_repository'
+    autoload :RedisRepository, 'feature/repository/redis_repository'
   end
 end


### PR DESCRIPTION
Registers repositories the first time that module is accessed.