### PR TITLE
Fixed Ruby warnings.

### DIFF
--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -42,6 +42,8 @@ module Feature
     @repository = repository
     if [true, false].include?(refresh)
       @auto_refresh = refresh
+      @refresh_after = nil
+      @next_refresh_after = nil
     else
       @auto_refresh = false
       @refresh_after = refresh


### PR DESCRIPTION
Fixes:
`warning: instance variable @refresh_after not initialized`
`warning: instance variable @next_refresh_after not initialized`

Can be seen by setting RUBYOPT='-w'